### PR TITLE
Refactor State API's persistence methods

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -146,7 +146,7 @@ To run the script we'll use `petctl`,
 
 ``` bash
 SPECS_FILE=~/torchelastic_workspace/specs.json
-python3 petctl.py run_job --size 2 --specs_file ${SPECS_FILE} --name ${user}-job examples/imagenet/main.py -- model-arch resnet101
+python3 petctl.py run_job --size 2 --specs_file ${SPECS_FILE} --name $(user)-job examples/imagenet/main.py -- model-arch resnet101
 ```
 
 In the example above, the named arguments, such as, `--size` and `--specs_file` are 
@@ -155,7 +155,7 @@ self explanatory and are arguments supplied to `petctl`. The positional argument
 ```
 [local script] -- [script args ...]
   -- or -- 
-[local directory] [script] -- [script args...]
+[local directory] -- [script] [script args...]
 ```
 
 If the first positional argument is a path to a script file, then the script
@@ -164,18 +164,18 @@ are passed through to the script.
 
 If the first positional argument is a directory, then a tarball of the directory
 is created and uploaded to S3 and is extracted on the worker-side. In this case
-the second positional argument is the path to the script **relative** to the
-specified directory and, as before, the arguments that follow `--` are passed
-through to the script.
+the first argument after the `--` delimiter is the path to the script **relative** to the
+specified directory and the rest of the arguments after the delimiter is passed 
+to the script.
 
 In our example we specified
 ```
-petctl.py run_job [...] examples/imagenet main.py -- --model_arch resenet 101
+petctl.py run_job [...] examples/imagenet/main.py -- --model_arch resenet 101
 ```
 
-As long as `main.py` is self contained, we could run this as
+We could have decided to specify the directory instead
 ```
-petctl.py run_job [...] examples/imagenet/main.py -- --model_arch resenet 101
+petctl.py run_job [...] examples/imagenet -- main.py --model_arch resenet 101
 ```
 
 (TIP) Besides a local script or directory you can run with scripts or `tar` files
@@ -183,10 +183,10 @@ that have already been uploaded to S3 or directly point it to a file or director
 on the container.
 ``` bash
 python3 petctl.py run_job [...] s3://my-bucket/my_script.py
-python3 petctl.py run_job [...] s3://my-bucket/my_dir.tar.gz my_script.py
+python3 petctl.py run_job [...] s3://my-bucket/my_dir.tar.gz -- my_script.py
 
 # or
-python3 petctl.py run_job [...] --no_upload /path/in/container/dir my_script.py
+python3 petctl.py run_job [...] --no_upload /path/in/container/dir -- my_script.py
 python3 petctl.py run_job [...] --no_upload /path/in/container/dir/my_script.py
 ```
 
@@ -213,7 +213,7 @@ that is monitoring the job!). In practice consider using EKS, Batch, or SageMake
 To stop the job and tear down the resources, use the `kill_job` command:
 
 ``` bash
-python3 petctl.py kill_job --name ${user}-job
+python3 petctl.py kill_job --name $(user)-job
 ```
 
 You'll notice that the two ASGs created with the `run_job` command are deleted.

--- a/aws/__init__.py
+++ b/aws/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/aws/autoscaling.py
+++ b/aws/autoscaling.py
@@ -185,6 +185,9 @@ class AutoScalingGroup:
 
         assert min_size <= size <= max_size
 
+        kwargs["size"] = size
+        kwargs["min_size"] = min_size
+        kwargs["max_size"] = max_size
         self.create_launch_config(name, **kwargs)
 
         log.info(f"Creating autoscaling group: {name}")

--- a/torchelastic/checkpoint/api.py
+++ b/torchelastic/checkpoint/api.py
@@ -64,7 +64,7 @@ class CheckpointUtil:
         TODO: Add retry?
         TODO: better logic to handle load checkpoint failure
         """
-        loaded_state = None
+
         try:
             log.info("Finding latest available checkpoint...")
             checkpoint = self.checkpoint_manager.get_latest_checkpoint()
@@ -75,9 +75,9 @@ class CheckpointUtil:
                 log.info("Loading checkpoint...")
                 with checkpoint.open_input_stream(_DEFAULT_CHECKPOINT_KEY) as stream:
                     # Start from simple with _DEFAULT_CHECKPOINT_KEY
-                    loaded_state = state.deserialize(stream)
+                    state.load(stream)
                     log.info("Load checkpoint successfully.")
-                    return loaded_state
+                    return state
         except Exception as e:
             log.error("Load checkpoint fail: {}".format(e))
             raise e
@@ -125,7 +125,7 @@ class CheckpointUtil:
             log.info("Saving checkpoint...")
             with checkpoint.open_output_stream(_DEFAULT_CHECKPOINT_KEY) as stream:
                 # Start from simple with _DEFAULT_CHECKPOINT_KEY
-                state.serialize(stream)
+                state.save(stream)
                 log.info("Save Checkpoint successfully.")
                 checkpoint.commit()
         except Exception as e:


### PR DESCRIPTION
Summary:
Makes state API's persistence (rollback and serialization) more coherent, consistent, and natural. Does the following:

* Renames `deep_copy` and `rollback` to `snapshot` and `apply`
* The semantics of `snapshot` and `apply` is that the state is recoverable by:
      ```
           any_user_defined_snapshot_obj = state.snapshot()
           modify_state(state)
           state.apply(any_user_defined_snapshot_obj)
           state.sync()
      ```
* Renames `serialize` and `deserialize` to `save` and `load` (to be consistent with torch)
* `State` provides a default implementation of `save` and `load` using `snapshot` and `apply`.
* Removes the redundant `supports_rollback()` method from `State`. By not implementing `snapshot/apply` the user indicates that rollback is not supported on the `State` object. If the user wants to checkpoint but not rollback they can implement the `save/load` and not implement `snapshot/apply`. If the user wants rollback support, they lose no performance (in comparison) in doing checkpoints so they might as well get checkpoint for free.
* Makes changes to the `test_mock` and `elastic classy_vision` code to be compliant with the new API.
* Makes imagenet example compliant with the new API.

NOTE: This change renders the imagenet example under `//fblearner/flow/projects/pytorch/elastic/imagenet` broken. However this example was already broken and has zero users. The task to fix this is T57831531.

Differential Revision: D18672302

