### PR TITLE
Move `is_closed` to `rendezvous_barrier`

### DIFF
--- a/test/test_mocks.py
+++ b/test/test_mocks.py
@@ -25,8 +25,8 @@ log = logging.getLogger(__name__)
 
 
 class TestDataset:
-    def __init__(self):
-        self.data = range(11, 31)
+    def __init__(self, range_start=11, range_end=31):
+        self.data = range(range_start, range_end)
         self.start_index = 0
 
         # All data up to "skip index" is considered previously read. This is

--- a/torchelastic/p2p/coordinator_p2p.py
+++ b/torchelastic/p2p/coordinator_p2p.py
@@ -61,6 +61,8 @@ class CoordinatorP2P(Coordinator):
     def rendezvous_barrier(self):
         self._destroy_process_group()
         try:
+            if self.rendezvous.is_closed():
+                raise RendezvousClosedException()
             self.store, self.rank, self.world_size = self.rendezvous.next_rendezvous()
         except RendezvousClosedException:
             # Sets the local variable to True
@@ -150,8 +152,7 @@ class CoordinatorP2P(Coordinator):
     @metrics.profile("torchelastic")
     def should_stop_training(self):
         # Check if coordinator wants the training to stop
-        # either stop_training flag is set or rendezvous is closed
-        return self.stop_training or self.rendezvous.is_closed()
+        return self.stop_training
 
     @metrics.profile("torchelastic")
     def signal_training_done(self):


### PR DESCRIPTION
Summary:
`is_closed` is a rendezvous implementation, it can be:
- `synchronized` to check whether rendezvous is closed, which might slow, but can avoid race condition
- `synchronized` which is faster but contains race condition

to support both, Move `is_closed` to `rendezvous_barrier`.

Differential Revision: D19133430

