### PR TITLE
Fix flaky tests

### DIFF
--- a/test/distributed/collectives_test.py
+++ b/test/distributed/collectives_test.py
@@ -6,8 +6,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.abs
 
+import logging
 import os
 import os.path
+import socket
 import unittest
 from hashlib import md5
 
@@ -17,15 +19,26 @@ import torchelastic.distributed as edist
 from torch.multiprocessing import Process, Queue
 
 
+log = logging.getLogger(__name__)
+
+
 def compute_checksum(data: np.ndarray) -> bytes:
     return md5(data).hexdigest().encode("utf-8")
 
 
-def init_process(rank, world_size, fn, input, q, backend="gloo"):
+def get_free_tcp_port():
+    tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    tcp.bind(("", 0))
+    addr, port = tcp.getsockname()
+    tcp.close()
+    return port
+
+
+def init_process(rank, world_size, fn, input, q, backend="gloo", port=28502):
     """ Initialize the distributed environment. """
     try:
         os.environ["MASTER_ADDR"] = "127.0.0.1"
-        os.environ["MASTER_PORT"] = "29502"
+        os.environ["MASTER_PORT"] = str(port)
         dist.init_process_group(backend, rank=rank, world_size=world_size)
         r = fn(rank, world_size, input)
         q.put(r)
@@ -38,14 +51,19 @@ def run_in_process_group(world_size, fn, input):
     assert not dist.is_initialized()
     processes = []
     q = Queue()
+    port = get_free_tcp_port()
+    log.info(f"using tcp port: {port}")
+    backend = "gloo"
     for rank in range(world_size - 1):
-        p = Process(target=init_process, args=(rank, world_size, fn, input, q))
+        p = Process(
+            target=init_process, args=(rank, world_size, fn, input, q, backend, port)
+        )
         p.start()
         processes.append(p)
 
     if world_size >= 1:
         # run 1 process in current unittest process for debug purpose
-        init_process(world_size - 1, world_size, fn, input, q)
+        init_process(world_size - 1, world_size, fn, input, q, backend, port)
 
     for p in processes:
         p.join()


### PR DESCRIPTION
Summary:
Test is flaky when run stress test. We did some investigation and found it due to port conflict, since we are using a const port in our tests, the port conflict can come from:
- same tests running in parallel in the same machine
- some other tests, or system using this static port

to fix this, we can find a free port before use it. (ideal way is run test in a container that everything is isolated, before that the approach mentioned above is a good workaround.)

Reviewed By: mehta-vikas

Differential Revision: D19173621

