### PR TITLE
Redo D19133430 (Move `is_closed` to `rendezvous_barrier`) (#22)

### DIFF
--- a/test/test_mocks.py
+++ b/test/test_mocks.py
@@ -25,8 +25,8 @@ log = logging.getLogger(__name__)
 
 
 class TestDataset:
-    def __init__(self):
-        self.data = range(11, 31)
+    def __init__(self, range_start=11, range_end=31):
+        self.data = range(range_start, range_end)
         self.start_index = 0
 
         # All data up to "skip index" is considered previously read. This is

--- a/torchelastic/p2p/coordinator_p2p.py
+++ b/torchelastic/p2p/coordinator_p2p.py
@@ -150,8 +150,7 @@ class CoordinatorP2P(Coordinator):
     @metrics.profile("torchelastic")
     def should_stop_training(self):
         # Check if coordinator wants the training to stop
-        # either stop_training flag is set or rendezvous is closed
-        return self.stop_training or self.rendezvous.is_closed()
+        return self.stop_training
 
     @metrics.profile("torchelastic")
     def signal_training_done(self):


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/elastic/pull/22

`is_closed` is a rendezvous implementation, it can be:
- `synchronized` to check whether rendezvous is closed, which might slow, but can avoid race condition
- `synchronized` which is faster but contains race condition

to support both, Move `is_closed` to `rendezvous_barrier`.

Differential Revision: D19321957

