### PR TITLE
fix typo in metrics readme causing error

### DIFF
--- a/torchelastic/metrics/README.md
+++ b/torchelastic/metrics/README.md
@@ -50,8 +50,8 @@ By adding the following configuration metrics in the `torchelastic` and
 ```python
 import torchelastic.metrics as metrics
 
-metrics.configure(metrics.ConsoleMetricsHandler(), group = "torchelastic")
-metrics.configure(metrics.ConsoleMetricsHandler(), group = "my_app")
+metrics.configure(metrics.ConsoleMetricHandler(), group = "torchelastic")
+metrics.configure(metrics.ConsoleMetricHandler(), group = "my_app")
 ``` 
 
 #### Implementing a Custom Metric Handler


### PR DESCRIPTION
Summary:
In torchelastic/metrics/api.py the handler is called
ConsoleMetricHandler, but it is ConsoleMetricsHandler in the readme which could
cause confusion for users who try to run this code.

Differential Revision: D19456953

