### PR TITLE
Use EtcdStore rather than TCPStore when using etcd_rdzv

### DIFF
--- a/test/distributed/utils_test.py
+++ b/test/distributed/utils_test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.abs
+
+import multiprocessing as mp
+import unittest
+from unittest.mock import patch
+
+import torchelastic.distributed as edist
+
+
+def _return_false():
+    return False
+
+
+def _return_true():
+    return True
+
+
+def _return_one():
+    return 1
+
+
+def _get_rank(ignored):
+    """
+    wrapper around torchelastic.distributed.get_rank()
+    take the element in the input argument as parameter
+    since multiprocessing.Pool.map requires the function to
+    """
+    return edist.get_rank()
+
+
+class TestUtils(unittest.TestCase):
+    @patch("torch.distributed.is_available", _return_true)
+    @patch("torch.distributed.is_initialized", _return_false)
+    def test_get_rank_no_process_group_initialized(self):
+        # always return rank 0 when process group is not initialized
+        num_procs = 4
+        with mp.Pool(num_procs) as p:
+            ret = p.map(_get_rank, range(0, num_procs))
+            for rank in ret:
+                self.assertEqual(0, rank)
+
+    @patch("torch.distributed.is_available", _return_false)
+    @patch("torch.distributed.is_initialized", _return_true)
+    def test_get_rank_no_dist_available(self):
+        # always return rank 0 when distributed torch is not available
+        num_procs = 4
+        with mp.Pool(num_procs) as p:
+            ret = p.map(_get_rank, range(0, num_procs))
+            for rank in ret:
+                self.assertEqual(0, rank)
+
+    @patch("torch.distributed.is_available", _return_true)
+    @patch("torch.distributed.is_initialized", _return_true)
+    @patch("torch.distributed.get_rank", _return_one)
+    def test_get_rank(self):
+        world_size = 4
+        with mp.Pool(world_size) as p:
+            ret = p.map(_get_rank, range(0, world_size))
+
+        # since we mocked a return value of 1
+        # from torch.distributed.get_rank()
+        # we expect that the sum of ranks == world_size
+        self.assertEqual(world_size, sum(ret))

--- a/torchelastic/distributed/__init__.py
+++ b/torchelastic/distributed/__init__.py
@@ -7,3 +7,4 @@
 # LICENSE file in the root directory of this source tree.
 
 from .collectives import *  # noqa F401
+from .utils import *  # noqa F401

--- a/torchelastic/distributed/utils.py
+++ b/torchelastic/distributed/utils.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch.distributed as dist
+
+
+def get_rank():
+    """
+    Simple wrapper for correctly getting rank in both distributed
+    / non-distributed settings
+    """
+    return dist.get_rank() if dist.is_available() and dist.is_initialized() else 0


### PR DESCRIPTION
Summary:
Background:

The rdzv interface returns a store as part of the `next()` API. We used to return a TCPStore since prior to torch 1.4 it was not possible to provide a python implementation of the `c10d::Store` interface because no trampoline class existed in the pybind definition.

TCPStore had a chicken&egg problem in the unittest context since the constructor on the "master" (rank0 == where the tcp store was hosted) block waits until all workers have joined and the workers need the ip and port of the master. However, finding an unused port and passing it to the TCPStore's constructor and workers has a race condition (which is exacerbated during stress tests). Hence we had to run the tests in `serial`mode. This is no longer necessary for `EtcdStore`.

There are two pending github issues that need this change (see attached tasks)

Differential Revision: D19511842

