### PR TITLE
Adding barrier to synchronize high variance operation between trainers

### DIFF
--- a/torchelastic/checkpoint/api.py
+++ b/torchelastic/checkpoint/api.py
@@ -10,7 +10,6 @@ import abc
 import logging
 from typing import List
 
-import torch.distributed as dist
 import torchelastic.distributed as edist
 import torchelastic.metrics as metrics
 
@@ -37,8 +36,9 @@ class CheckpointBarrier(object):
     Checkpoint Barrier
     """
 
-    def __init__(self, rank):
+    def __init__(self, rank, coordinator):
         self.rank = rank
+        self.coordinator = coordinator
 
     def __enter__(self):
         return self
@@ -47,7 +47,7 @@ class CheckpointBarrier(object):
         # We put a explicit barrier here to make sure all trainer sync
         # after checkpoint was loaded
         log.info(f"Rank {self.rank} enter checkpoint barrier")
-        dist.barrier()
+        self.coordinator.barrier()
         log.info(f"Rank {self.rank} exit checkpoint barrier")
 
 
@@ -157,7 +157,7 @@ class CheckpointUtil:
             # (reduce_all) in train_step(state). State are all good when
             # We come here, otherwise it will break out of the loop if any
             # exception is raised.
-            with CheckpointBarrier(rank):
+            with CheckpointBarrier(rank, self.coordinator):
                 if rank == 0:
                     self._do_save_checkpoint(state)
 

--- a/torchelastic/coordinator.py
+++ b/torchelastic/coordinator.py
@@ -51,6 +51,13 @@ class Coordinator(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def barrier(self):
+        """
+        A regular barrier (no rendezvous) for synchronizing trainers.
+        """
+        pass
+
+    @abc.abstractmethod
     def init_process_group(self):
         """
         Creates a ProcessGroup which manages collective and p2p communication

--- a/torchelastic/p2p/coordinator_p2p.py
+++ b/torchelastic/p2p/coordinator_p2p.py
@@ -32,7 +32,12 @@ class CoordinatorP2P(Coordinator):
     MONITOR_PROGRESS_FREQ = 1000
 
     def __init__(
-        self, c10d_backend, init_method, max_num_trainers, process_group_timeout=10000
+        self,
+        c10d_backend,
+        init_method,
+        max_num_trainers,
+        process_group_timeout=10000,
+        control_plane_pg_timeout=60000,  # default 10 mins for control plane pg timeout
     ):
         self.c10d_backend = c10d_backend
         self.init_method = init_method
@@ -43,6 +48,7 @@ class CoordinatorP2P(Coordinator):
 
         self.max_num_trainers = max_num_trainers
         self.process_group_timeout = process_group_timeout
+        self.control_plane_pg_timeout = control_plane_pg_timeout
         self.rank = -1
         self.world_size = 0
         self.is_worker_straggler = False
@@ -86,6 +92,11 @@ class CoordinatorP2P(Coordinator):
         return self.store, self.rank, self.world_size
 
     @metrics.profile("torchelastic")
+    def barrier(self):
+        # Use gloo process group to implement a barrier in case NCCL get stuck
+        dist.barrier(group=self.coordinator_process_group)
+
+    @metrics.profile("torchelastic")
     def init_process_group(self):
         self.monitor_progress_step = 0
         dist.init_process_group(
@@ -104,7 +115,7 @@ class CoordinatorP2P(Coordinator):
             # to make it portable with NCCL)
             self.coordinator_process_group = dist.new_group(
                 backend=dist.distributed_c10d.Backend.GLOO,
-                timeout=timedelta(milliseconds=self.process_group_timeout),
+                timeout=timedelta(milliseconds=self.control_plane_pg_timeout),
             )
 
         log.info(

--- a/torchelastic/train_loop.py
+++ b/torchelastic/train_loop.py
@@ -65,6 +65,7 @@ def train(elastic_coordinator, train_step, state):
                 get_elapsed_time_ms(state_sync_start_time),
             )
             checkpoint_util.set_checkpoint_loaded()
+            elastic_coordinator.barrier()
             log.info("Rank {0} synced state with other nodes".format(rank))
         except StopException:
             log.info("Rank {0} received stopped signal. Exiting training.".format(rank))


### PR DESCRIPTION
Summary:
Adding barrier to synchronize high variance operation between trainers.

Latency of some operations can be various between trainers, this can introduce timeout, trainer might stuck while timeout. Such as data loader. The initialization time for data loader of some trainer can be longer than others, this depends on the implementation of data loader/data set (eg: throttling can make the different).

We use gloo for the barrier implementation other than NCCL, as gloo is more stable than NCCL (to handle timeout & stuck).

Differential Revision: D19576695

