### PR TITLE
add formatter_python.sh for external contributor, and setup circleci to run linter on builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,25 @@ run_tests: &run_tests
 # tests
 # ------------------------------------------------------------------------------
 jobs:
+  linter:
+    <<: *cpu
+    working_directory: ~/torchelastic
+    steps:
+      - checkout
+
+      - <<: *install_python
+
+      - run:
+            name: setup lint
+            command: |
+                pip install --upgrade pip
+                pip install --progress-bar off black isort
+
+      - run:
+            name: run isort and black
+            command: |
+              bash ./scripts/formatter_python.sh
+
   cpu_tests:
     <<: *cpu
 
@@ -172,6 +191,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - linter
       - cpu_tests
       # no gpu tests for now; uncomment to enable
       # - gpu_tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ We actively welcome your pull requests.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.
-5. Make sure your code lints.
+5. Make sure your code lints (run `scripts/formatter_python.sh`).
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
 
 ## Contributor License Agreement ("CLA")

--- a/scripts/formatter_python.sh
+++ b/scripts/formatter_python.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+if [ ! "$(black --version)" ]
+then
+    echo "Please install black."
+    exit 1
+fi
+if [ ! "$(isort --version)" ]
+then
+    echo "Please install isort."
+    exit 1
+fi
+
+# cd to the project directory
+cd "$(dirname "$0")/.." || exit 1
+
+GIT_URL_1="https://github.com/pytorch/elastic.git"
+GIT_URL_2="git@github.com:pytorch/elastic.git"
+
+UPSTREAM_URL="$(git config remote.upstream.url)"
+
+if [ -z "$UPSTREAM_URL" ]
+then
+    echo "Setting upstream remote to $GIT_URL_1"
+    git remote add upstream "$GIT_URL_1"
+elif [ "$UPSTREAM_URL" != "$GIT_URL_1" ] && \
+     [ "$UPSTREAM_URL" != "$GIT_URL_2" ]
+then
+    echo "upstream remote set to $UPSTREAM_URL."
+    echo "Please delete the upstream remote or set it to $GIT_URL_1 to use this script."
+    exit 1
+fi
+
+# fetch upstream
+git fetch upstream
+
+
+CHANGED_FILES="$(git diff --diff-filter=ACMRT --name-only upstream/master | grep '\.py$' | tr '\n' ' ')"
+
+if [ "$CHANGED_FILES" != "" ]
+then
+    echo "Running isort..."
+    isort "$CHANGED_FILES" --recursive --multi-line 3 --trailing-comma --force-grid-wrap 0 \
+    --line-width 88 --lines-after-imports 2 --combine-as --section-default THIRDPARTY
+
+    echo "Running black..."
+    black "$CHANGED_FILES"
+else
+    echo "No changes made to any Python files. Nothing to do."
+    exit 0
+fi
+
+# Check if any files were modified by running isort + black
+# If so, then the files were formatted incorrectly (e.g. did not pass lint)
+CHANGED_FILES="$(git diff --name-only | grep '\.py$' | tr '\n' ' ')"
+if [ "$CHANGED_FILES" != "" ]
+then
+    # need this so that CircleCI fails
+    exit 1
+fi


### PR DESCRIPTION
Summary:
External contributors can run:
```
scripts/formatter_python.sh
```
to simulate `arc lint`

Setup lint job in circleci

credit: ClassyVision (https://github.com/facebookresearch/ClassyVision/blob/master/scripts/formatter.sh)

Differential Revision: D19656921

