### PR TITLE
Implement countdown timer with a localhost implementation of timer client and server

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,9 +6,24 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import ctypes
 import multiprocessing
 import queue
 import uuid
+
+
+def is_asan():
+    """Determines if the Python interpreter is running with ASAN"""
+    return hasattr(ctypes.CDLL(""), "__asan_init")
+
+
+def is_tsan():
+    """Determines if the Python interpreter is running with TSAN"""
+    return hasattr(ctypes.CDLL(""), "__tsan_init")
+
+
+def is_asan_or_tsan():
+    return is_asan() or is_tsan()
 
 
 def _get_or_raise(qout, qerr):

--- a/test/timer/local_timer_example.py
+++ b/test/timer/local_timer_example.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import logging
+import multiprocessing as mp
+import signal
+import time
+import unittest
+
+import torch.multiprocessing as torch_mp
+import torchelastic.timer as timer
+from test_utils import is_asan
+
+
+logging.basicConfig(
+    level=logging.INFO, format="[%(levelname)s] %(asctime)s %(module)s: %(message)s"
+)
+
+
+def _happy_function(rank, mp_queue):
+    timer.configure(timer.LocalTimerClient(mp_queue))
+    with timer.expires(after=1):
+        time.sleep(0.5)
+
+
+def _stuck_function(rank, mp_queue):
+    timer.configure(timer.LocalTimerClient(mp_queue))
+    with timer.expires(after=1):
+        time.sleep(5)
+
+
+class LocalTimerExample(unittest.TestCase):
+    """
+    Demonstrates how to use LocalTimerServer and LocalTimerClient
+    to enforce expiration of code-blocks.
+
+    Since torch multiprocessing's ``start_process`` method currently
+    does not take the multiprocessing context as parameter argument
+    there is no way to create the mp.Queue in the correct
+    context BEFORE spawning child processes. Once the ``start_process``
+    API is changed in torch, then re-enable ``test_torch_mp_example``
+    unittest. As of now this will SIGSEGV.
+    """
+
+    @unittest.skip("re-enable when torch_mp.spawn() takes mp context as param")
+    def test_torch_mp_example(self):
+        # in practice set the max_interval to a larger value (e.g. 60 seconds)
+        ctx = mp.get_context("spawn")
+        mp_queue = ctx.Queue()
+        server = timer.LocalTimerServer(mp_queue, max_interval=0.01)
+        server.start()
+
+        world_size = 8
+        # all processes should complete successfully
+        # since start_process does NOT take context as parameter argument yet
+        # this method WILL FAIL (hence the test is disabled)
+        torch_mp.start_process(
+            fn=_happy_function, args=(mp_queue,), nprocs=world_size, context=ctx
+        )
+
+        with self.assertRaises(Exception):
+            # torch.multiprocessing.spawn kills all sub-procs
+            # if one of them gets killed
+            torch_mp.start_process(
+                fn=_stuck_function, args=(mp_queue,), nprocs=world_size, context=ctx
+            )
+
+        server.stop()
+
+    @unittest.skip(is_asan())
+    def test_example_start_method_spawn(self):
+        self._run_example_with(start_method="spawn")
+
+    @unittest.skip(is_asan())
+    def test_example_start_method_forkserver(self):
+        self._run_example_with(start_method="forkserver")
+
+    def test_example_start_method_fork(self):
+        self._run_example_with(start_method="fork")
+
+    def _run_example_with(self, start_method):
+        spawn_ctx = mp.get_context(start_method)
+        mp_queue = spawn_ctx.Queue()
+        server = timer.LocalTimerServer(mp_queue, max_interval=0.01)
+        server.start()
+
+        world_size = 8
+        processes = []
+        for i in range(0, world_size):
+            if i % 2 == 0:
+                p = spawn_ctx.Process(target=_stuck_function, args=(i, mp_queue))
+            else:
+                p = spawn_ctx.Process(target=_happy_function, args=(i, mp_queue))
+            p.start()
+            processes.append(p)
+
+        for i in range(0, world_size):
+            p = processes[i]
+            p.join()
+            if i % 2 == 0:
+                self.assertEqual(-signal.SIGKILL, p.exitcode)
+            else:
+                self.assertEqual(0, p.exitcode)
+
+        server.stop()

--- a/test/timer/local_timer_test.py
+++ b/test/timer/local_timer_test.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import logging
+import multiprocessing as mp
+import signal
+import time
+import unittest
+import unittest.mock as mock
+
+import torchelastic.timer as timer
+from torchelastic.timer import TimerRequest
+from torchelastic.timer.local_timer import MultiprocessingRequestQueue
+
+
+logging.basicConfig(
+    level=logging.INFO, format="[%(levelname)s] %(asctime)s %(module)s: %(message)s"
+)
+
+
+class LocalTimerTest(unittest.TestCase):
+    def setUp(self):
+        self.mp_queue = mp.Queue()
+        self.max_interval = 0.01
+        self.server = timer.LocalTimerServer(self.mp_queue, self.max_interval)
+        self.server.start()
+
+    def tearDown(self):
+        self.server.stop()
+
+    def test_exception_propagation(self):
+        with self.assertRaises(Exception, msg="foobar"):
+            with timer.expires(after=1):
+                raise Exception("foobar")
+
+    def test_no_client(self):
+        # no timer client configured; exception expected
+        with self.assertRaises(RuntimeError):
+            with timer.expires(after=1):
+                pass
+
+    def test_client_interaction(self):
+        # no timer client configured but one passed in explicitly
+        # no exception expected
+        timer_client = timer.LocalTimerClient(self.mp_queue)
+        timer_client.acquire = mock.MagicMock(wraps=timer_client.acquire)
+        timer_client.release = mock.MagicMock(wraps=timer_client.release)
+        with timer.expires(after=1, scope="test", client=timer_client):
+            pass
+
+        timer_client.acquire.assert_called_once_with("test", mock.ANY)
+        timer_client.release.assert_called_once_with("test")
+
+    def test_happy_path(self):
+        timer.configure(timer.LocalTimerClient(self.mp_queue))
+        with timer.expires(after=0.5):
+            time.sleep(0.1)
+
+    def test_get_timer_recursive(self):
+        """
+        If a function acquires a countdown timer with default scope,
+        then recursive calls to the function should re-acquire the
+        timer rather than creating a new one. That is only the last
+        recursive call's timer will take effect.
+        """
+        self.server.start()
+        timer.configure(timer.LocalTimerClient(self.mp_queue))
+
+        # func should not time out
+        def func(n):
+            if n > 0:
+                with timer.expires(after=0.1):
+                    func(n - 1)
+                    time.sleep(0.05)
+
+        func(4)
+
+        # func2 should time out
+        def func2(n):
+            if n > 0:
+                with timer.expires(after=0.1):
+                    func2(n - 1)
+                    time.sleep(0.2)
+
+        p = mp.Process(target=func2, args=(2,))
+        p.start()
+        p.join()
+        self.assertEqual(-signal.SIGKILL, p.exitcode)
+
+    @staticmethod
+    def _run(mp_queue, timeout, duration):
+        client = timer.LocalTimerClient(mp_queue)
+        timer.configure(client)
+
+        with timer.expires(after=timeout):
+            time.sleep(duration)
+
+    def test_timer(self):
+        timeout = 0.1
+        duration = 1
+        p = mp.Process(target=self._run, args=(self.mp_queue, timeout, duration))
+        p.start()
+        p.join()
+        self.assertEqual(-signal.SIGKILL, p.exitcode)
+
+
+def _enqueue_on_interval(mp_queue, n, interval, sem):
+    """
+    enqueues ``n`` timer requests into ``mp_queue`` one element per
+    interval seconds. Releases the given semaphore once before going to work.
+    """
+    sem.release()
+    for i in range(0, n):
+        mp_queue.put(TimerRequest(i, "test_scope", 0))
+        time.sleep(interval)
+
+
+class MultiprocessingRequestQueueTest(unittest.TestCase):
+    def test_get(self):
+        mp_queue = mp.Queue()
+        request_queue = MultiprocessingRequestQueue(mp_queue)
+
+        requests = request_queue.get(1, timeout=0.01)
+        self.assertEqual(0, len(requests))
+
+        request = TimerRequest(1, "test_scope", 0)
+        mp_queue.put(request)
+        requests = request_queue.get(2, timeout=0.01)
+        self.assertEqual(1, len(requests))
+        self.assertIn(request, requests)
+
+    def test_get_size(self):
+        """
+        Creates a "producer" process that enqueues ``n`` elements
+        every ``interval`` seconds. Asserts that a ``get(n, timeout=n*interval+delta)``
+        yields all ``n`` elements.
+        """
+        mp_queue = mp.Queue()
+        request_queue = MultiprocessingRequestQueue(mp_queue)
+        n = 10
+        interval = 0.1
+        sem = mp.Semaphore(0)
+
+        p = mp.Process(target=_enqueue_on_interval, args=(mp_queue, n, interval, sem))
+        p.start()
+
+        sem.acquire()  # blocks until the process has started to run the function
+        timeout = interval * (n + 1)
+        start = time.time()
+        requests = request_queue.get(n, timeout=timeout)
+        self.assertLessEqual(time.time() - start, timeout + interval)
+        self.assertEqual(n, len(requests))
+
+    def test_get_less_than_size(self):
+        """
+        Tests slow producer.
+        Creates a "producer" process that enqueues ``n`` elements
+        every ``interval`` seconds. Asserts that a ``get(n, timeout=(interval * n/2))``
+        yields at most ``n/2`` elements.
+        """
+        mp_queue = mp.Queue()
+        request_queue = MultiprocessingRequestQueue(mp_queue)
+        n = 10
+        interval = 0.1
+        sem = mp.Semaphore(0)
+
+        p = mp.Process(target=_enqueue_on_interval, args=(mp_queue, n, interval, sem))
+        p.start()
+
+        sem.acquire()  # blocks until the process has started to run the function
+        requests = request_queue.get(n, timeout=(interval * (n / 2)))
+        self.assertLessEqual(n / 2, len(requests))
+
+
+class LocalTimerServerTest(unittest.TestCase):
+    def setUp(self):
+        self.mp_queue = mp.Queue()
+        self.max_interval = 0.01
+        self.server = timer.LocalTimerServer(self.mp_queue, self.max_interval)
+
+    def tearDown(self):
+        self.server.stop()
+
+    def test_watchdog_call_count(self):
+        """
+        checks that the watchdog function ran wait/interval +- 1 times
+        """
+        self.server._run_watchdog = mock.MagicMock(wraps=self.server._run_watchdog)
+
+        wait = 0.1
+
+        self.server.start()
+        time.sleep(wait)
+        self.server.stop()
+        watchdog_call_count = self.server._run_watchdog.call_count
+        self.assertGreaterEqual(watchdog_call_count, int(wait / self.max_interval) - 1)
+        self.assertLessEqual(watchdog_call_count, int(wait / self.max_interval) + 1)
+
+    def test_watchdog_empty_queue(self):
+        """
+        checks that the watchdog can run on an empty queue
+        """
+        self.server._run_watchdog()
+
+    def _expired_timer(self, pid, scope):
+        expired = time.time() - 60
+        return TimerRequest(worker_id=pid, scope_id=scope, expiration_time=expired)
+
+    def _valid_timer(self, pid, scope):
+        valid = time.time() + 60
+        return TimerRequest(worker_id=pid, scope_id=scope, expiration_time=valid)
+
+    def _release_timer(self, pid, scope):
+        return TimerRequest(worker_id=pid, scope_id=scope, expiration_time=-1)
+
+    @mock.patch("os.kill")
+    def test_expired_timers(self, mock_os_kill):
+        """
+        tests that a single expired timer on a process should terminate
+        the process and clean up all pending timers that was owned by the process
+        """
+        test_pid = -3
+        self.mp_queue.put(self._expired_timer(pid=test_pid, scope="test1"))
+        self.mp_queue.put(self._valid_timer(pid=test_pid, scope="test2"))
+
+        self.server._run_watchdog()
+
+        self.assertEqual(0, len(self.server._timers))
+        mock_os_kill.assert_called_once_with(test_pid, signal.SIGKILL)
+
+    @mock.patch("os.kill")
+    def test_acquire_release(self, mock_os_kill):
+        """
+        tests that:
+          1. a timer can be acquired then released (should not terminate process)
+          2. a timer can be vacuously released (e.g. no-op)
+        """
+        test_pid = -3
+        self.mp_queue.put(self._valid_timer(pid=test_pid, scope="test1"))
+        self.mp_queue.put(self._release_timer(pid=test_pid, scope="test1"))
+        self.mp_queue.put(self._release_timer(pid=test_pid, scope="test2"))
+
+        self.server._run_watchdog()
+
+        self.assertEqual(0, len(self.server._timers))
+        mock_os_kill.assert_not_called()
+
+    @mock.patch("os.kill")
+    def test_valid_timers(self, mock_os_kill):
+        """
+        tests that valid timers are processed correctly and the process is left alone
+        """
+        self.mp_queue.put(self._valid_timer(pid=-3, scope="test1"))
+        self.mp_queue.put(self._valid_timer(pid=-3, scope="test2"))
+        self.mp_queue.put(self._valid_timer(pid=-2, scope="test1"))
+        self.mp_queue.put(self._valid_timer(pid=-2, scope="test2"))
+
+        self.server._run_watchdog()
+
+        self.assertEqual(4, len(self.server._timers))
+        self.assertTrue((-3, "test1") in self.server._timers)
+        self.assertTrue((-3, "test2") in self.server._timers)
+        self.assertTrue((-2, "test1") in self.server._timers)
+        self.assertTrue((-2, "test2") in self.server._timers)
+        mock_os_kill.assert_not_called()

--- a/torchelastic/timer/__init__.py
+++ b/torchelastic/timer/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .api import *  # noqa F401
+from .local_timer import (  # noqa F401
+    LocalTimerClient,
+    LocalTimerServer,
+    MultiprocessingRequestQueue,
+)

--- a/torchelastic/timer/api.py
+++ b/torchelastic/timer/api.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import abc
+import logging
+import threading
+import time
+from contextlib import contextmanager
+from inspect import getframeinfo, stack
+from typing import Any, Dict, List, Set
+
+
+class TimerRequest:
+    """
+    Data object representing a countdown timer acquisition and release
+    that is used between the ``TimerClient`` and ``TimerServer``.
+    A negative ``expiration_time`` should be interpreted as a "release"
+    request.
+
+    """
+
+    __slots__ = ("worker_id", "scope_id", "expiration_time")
+
+    def __init__(self, worker_id: Any, scope_id: str, expiration_time: float):
+        self.worker_id = worker_id
+        self.scope_id = scope_id
+        self.expiration_time = expiration_time
+
+    def __eq__(self, other):
+        if isinstance(other, TimerRequest):
+            return (
+                self.worker_id == other.worker_id
+                and self.scope_id == other.scope_id
+                and self.expiration_time == other.expiration_time
+            )
+        return False
+
+
+class TimerClient(abc.ABC):
+    """
+    Client library to acquire and release countdown timers by communicating
+    with the TimerServer.
+    """
+
+    @abc.abstractmethod
+    def acquire(self, scope_id: str, expiration_time: float) -> None:
+        """
+        Acquires a timer for the worker that holds this client object
+        given the scope_id and expiration_time. Typically registers
+        the timer with the TimerServer.
+        """
+        pass
+
+    @abc.abstractmethod
+    def release(self, scope_id: str):
+        """
+        Releases the timer for the ``scope_id`` on the worker this
+        client represents. After this method is
+        called, the countdown timer on the scope is no longer in effect.
+        """
+        pass
+
+
+class RequestQueue(abc.ABC):
+    """
+    Consumer queue holding timer acquisition/release requests
+    """
+
+    @abc.abstractmethod
+    def size(self) -> int:
+        """
+        Returns the size of the queue at the time this method is called.
+        Note that by the time ``get`` is called the size of the queue
+        may have increased. The size of the queue should not decrease
+        until the ``get`` method is called. That is, the following assertion
+        should hold:
+
+        size = q.size()
+        res = q.get(size, timeout=0)
+        assert size == len(res)
+
+        -- or --
+
+        size = q.size()
+        res = q.get(size * 2, timeout=1)
+        assert size <= len(res) <= size * 2
+        """
+        pass
+
+    @abc.abstractmethod
+    def get(self, size: int, timeout: float) -> List[TimerRequest]:
+        """
+        Gets up to ``size`` number of timer requests in a blocking fashion
+        (no more than ``timeout`` seconds).
+        """
+        pass
+
+
+class TimerServer(abc.ABC):
+    """
+    Entity that monitors active timers and expires them
+    in a timely fashion. This server is responsible for
+    reaping workers that have expired timers.
+    """
+
+    def __init__(
+        self, request_queue: RequestQueue, max_interval: float, daemon: bool = True
+    ):
+        """
+        :param request_queue: Consumer ``RequestQueue``
+        :param max_interval: max time (in seconds) to wait
+                             for an item in the request_queue
+        :param daemon: whether to run the watchdog thread as a daemon
+        """
+        super().__init__()
+        self._request_queue = request_queue
+        self._max_interval = max_interval
+        self._daemon = daemon
+        self._watchdog_thread = None
+        self._stop_signaled = False
+
+    @abc.abstractmethod
+    def register_timers(self, timer_requests: List[TimerRequest]) -> None:
+        """
+        Processes the incoming timer requests and registers them with the server.
+        The timer request can either be a acquire-timer or release-timer request.
+        Timer requests with a negative expiration_time should be interpreted
+        as a release-timer request.
+        """
+        pass
+
+    @abc.abstractmethod
+    def clear_timers(self, worker_ids: Set[Any]) -> None:
+        """
+        Clears all timers for the given ``worker_ids``.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_expired_timers(self, deadline: float) -> Dict[str, List[TimerRequest]]:
+        """
+        Returns all expired timers for each worker_id. An expired timer
+        is a timer for which the expiration_time is less than or equal to
+        the provided deadline.
+        """
+        pass
+
+    @abc.abstractmethod
+    def _reap_worker(self, worker_id: Any) -> bool:
+        """
+        Reaps the given worker. Returns True if the worker has been
+        successfully reaped, False otherwise.
+        """
+
+    def _watchdog_loop(self):
+        while not self._stop_signaled:
+            try:
+                self._run_watchdog()
+            except Exception as e:
+                logging.error("Error running watchdog", exc_info=e)
+
+    def _run_watchdog(self):
+        batch_size = max(1, self._request_queue.size())
+        timer_requests = self._request_queue.get(batch_size, self._max_interval)
+        self.register_timers(timer_requests)
+        now = time.time()
+        reaped_worker_ids = set()
+        for worker_id, expired_timers in self.get_expired_timers(now).items():
+            logging.info(
+                f"Reaping worker_id=[{worker_id}]."
+                f" Expired timers: {self._get_scopes(expired_timers)}"
+            )
+            if self._reap_worker(worker_id):
+                logging.info(f"Successfully reaped worker=[{worker_id}]")
+                reaped_worker_ids.add(worker_id)
+            else:
+                logging.error(
+                    f"Error reaping worker=[{worker_id}]. Will retry on next watchdog."
+                )
+        self.clear_timers(reaped_worker_ids)
+
+    def _get_scopes(self, timer_requests):
+        return [r.scope_id for r in timer_requests]
+
+    def start(self) -> None:
+        logging.info(
+            f"Starting {self.__class__.__name__}..."
+            f" max_interval={self._max_interval},"
+            f" daemon={self._daemon}"
+        )
+        self._watchdog_thread = threading.Thread(
+            target=self._watchdog_loop, daemon=self._daemon
+        )
+        self._watchdog_thread.start()
+
+    def stop(self) -> None:
+        self._stop_signaled = True
+        if self._watchdog_thread:
+            logging.info(f"Stopping watchdog thread...")
+            self._watchdog_thread.join(self._max_interval)
+            self._watchdog_thread = None
+        else:
+            logging.info(f"No watchdog thread running, doing nothing")
+
+
+_timer_client = None
+
+
+def configure(timer_client: TimerClient):
+    global _timer_client
+    _timer_client = timer_client
+
+
+@contextmanager
+def expires(after: float, scope: str = None, client: TimerClient = None) -> None:
+    """
+    Acquires a countdown timer that expires in ``after`` seconds from now,
+    unless the code-block that it wraps is finished within the timeframe.
+    When the timer expires, this worker is eligible to be reaped. The
+    exact meaning of "reaped" depends on the client implementation. In
+    most cases, reaping means to terminate the worker process.
+    Note that the worker is NOT guaranteed to be reaped at exactly
+    ``time.now() + after``, but rather the worker is "eligible" for being
+    reaped and the ``TimerServer`` that the client talks to will ultimately
+    make the decision when and how to reap the workers with expired timers.
+
+    Usage:
+
+    ```
+        torchelastic.timer.configure(LocalTimerClient())
+        with expires(after=10):
+            torch.distributed.all_reduce(...)
+    ```
+    """
+    if client is None:
+        if _timer_client is None:
+            raise RuntimeError("Configure timer client before using coundown timers.")
+        client = _timer_client
+    if scope is None:
+        # grab the caller file + lineno
+        caller = getframeinfo(stack()[1][0])
+        scope = f"{caller.filename}#{caller.lineno}"
+    expiration = time.time() + after
+    client.acquire(scope, expiration)
+    try:
+        yield
+    finally:
+        client.release(scope)

--- a/torchelastic/timer/local_timer.py
+++ b/torchelastic/timer/local_timer.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import multiprocessing as mp
+import os
+import signal
+import time
+from queue import Empty
+from typing import Dict, List, Set
+
+from .api import RequestQueue, TimerClient, TimerRequest, TimerServer
+
+
+class LocalTimerClient(TimerClient):
+    def __init__(self, mp_queue):
+        super().__init__()
+        self._mp_queue = mp_queue
+
+    def acquire(self, scope_id, expiration_time):
+        pid = os.getpid()
+        acquire_request = TimerRequest(pid, scope_id, expiration_time)
+        self._mp_queue.put(acquire_request)
+
+    def release(self, scope_id):
+        pid = os.getpid()
+        release_request = TimerRequest(pid, scope_id, -1)
+        self._mp_queue.put(release_request)
+
+
+class MultiprocessingRequestQueue(RequestQueue):
+    """
+    A ``RequestQueue`` backed by python ``multiprocessing.Queue``
+    """
+
+    def __init__(self, mp_queue: mp.Queue):
+        super().__init__()
+        self._mp_queue = mp_queue
+
+    def size(self) -> int:
+        return self._mp_queue.qsize()
+
+    def get(self, size, timeout: float) -> List[TimerRequest]:
+        requests = []
+        wait = timeout
+        for _ in range(0, size):
+            start = time.time()
+
+            try:
+                r = self._mp_queue.get(block=True, timeout=wait)
+            except Empty:
+                break
+
+            requests.append(r)
+            wait = wait - (time.time() - start)
+            if wait <= 0:
+                break
+
+        return requests
+
+
+class LocalTimerServer(TimerServer):
+    def __init__(
+        self, mp_queue: mp.Queue, max_interval: float = 60, daemon: bool = True
+    ):
+        super().__init__(MultiprocessingRequestQueue(mp_queue), max_interval, daemon)
+        self._timers = {}
+
+    def register_timers(self, timer_requests: List[TimerRequest]) -> None:
+        for request in timer_requests:
+            pid = request.worker_id
+            scope_id = request.scope_id
+            expiration_time = request.expiration_time
+
+            # negative expiration is a proxy for a release call
+            if expiration_time < 0:
+                self._timers.pop((pid, scope_id), None)
+            else:
+                self._timers[(pid, scope_id)] = request
+
+    def clear_timers(self, worker_ids: Set[int]) -> None:
+        for (pid, scope_id) in list(self._timers.keys()):
+            if pid in worker_ids:
+                self._timers.pop((pid, scope_id))
+
+    def get_expired_timers(self, deadline: float) -> Dict[str, List[TimerRequest]]:
+        # pid -> [timer_requests...]
+        expired_timers = {}
+        for request in self._timers.values():
+            if request.expiration_time <= deadline:
+                expired_scopes = expired_timers.setdefault(request.worker_id, [])
+                expired_scopes.append(request)
+        return expired_timers
+
+    def _reap_worker(self, worker_id: int) -> bool:
+        try:
+            os.kill(worker_id, signal.SIGKILL)
+            return True
+        except ProcessLookupError:
+            logging.info(f"Process with pid={worker_id} does not exist. Skipping")
+            return True
+        except Exception as e:
+            logging.error(f"Error terminating pid={worker_id}", exc_info=e)
+        return False


### PR DESCRIPTION
Summary:
* Countdown timer that expires the code it wraps after `n` seconds.
* The `TimerServer` is responsible for detecting expired timers and reaping the worker
* `LocalTimerServer` is a in-host implementation of `TimerServer` that uses `multiprocessing.Queue` as the message bus between processes and reaps (a.k.a terminates) pids
* `TimerClient` is responsible for sending timer acquire and release messages to `TimerServer` (usually the client and server are implemented and used in pairs)
* See `test/timer/local_timer_example.py` for E2E usage.

NOTE: there is something funny going on with `torch_mp.spawn`. All my unittests worked in the default multiprocessing context (fork) but fail with `spawn`. Going to look into this tomorrow and update the diff. This is why the `local_timer_example.py` is disabled as a unittest.

Differential Revision: D19740898

