### PR TITLE
Introduce PET state generator

### DIFF
--- a/torchelastic/__init__.py
+++ b/torchelastic/__init__.py
@@ -8,6 +8,6 @@
 
 from .coordinator import Coordinator, NonRetryableException, StopException  # noqa F401
 from .state import State  # noqa F401
-from .train_loop import train  # noqa F401
+from .train_loop import train, train_with_state_generator  # noqa F401
 from .version import __version__ as __version__  # noqa F401
 from .worker_stats import SimpleWorkerStats, WorkerStats  # noqa F401


### PR DESCRIPTION
Summary: Today PET requires a train_step and runs a managed train_loop, PET controls the training process. This is not friendly to applications that have their own customized training loop, which make user adoption a little challenge. To mitigate this problem we propose *PET state generator*. It treat customized train_loop as a python generator that yields a sequence of PET states. This state generator approach returns the control to user code and simply the programing model very much.

Differential Revision: D19910960

