### PR TITLE
[pet/oss] fix broken circleci test runs due to missing numpy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@
 #  pip (cpu): pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 #  pip (gpu): pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
 # See https://pytorch.org/
+numpy
 torch>1.4.0
 python-etcd>=0.4.5


### PR DESCRIPTION
`pip install torch` does not install `numpy`, torchelastic had no explicit dependency on `numpy` listed in the requirements.txt. CircleCI tests started failing due to this missing dependency (see https://circleci.com/workflow-run/534c270d-ab76-42d5-9695-54ba51f8840c). The tests used to work because the venv (which had numpy installed) used to be cached and reused, but recently the cache got cleared so we ended up creating a new venv with no numpy installed.