### PR TITLE
Use __slots__ over dataclass since it is not supported in python 3.6, add __init__.py to test/timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ guide](aws/README.md).
 
 ## Requirements
 torchelastic requires
-* python3
+* python3 (3.6+)
 * torch
 * etcd
 

--- a/test/timer/__init__.py
+++ b/test/timer/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/timer/api_test.py
+++ b/test/timer/api_test.py
@@ -58,8 +58,8 @@ class MockTimerServer(TimerServer):
 
 
 class TimerApiTest(unittest.TestCase):
-    @mock.patch("pytorch.elastic.test.timer.api_test.MockTimerServer.register_timers")
-    @mock.patch("pytorch.elastic.test.timer.api_test.MockTimerServer.clear_timers")
+    @mock.patch("timer.api_test.MockTimerServer.register_timers")
+    @mock.patch("timer.api_test.MockTimerServer.clear_timers")
     def test_run_watchdog(self, mock_clear_timers, mock_register_timers):
         """
         tests that when a ``_reap_worker()`` method throws an exception

--- a/test/timer/local_timer_test.py
+++ b/test/timer/local_timer_test.py
@@ -34,6 +34,7 @@ class LocalTimerTest(unittest.TestCase):
 
     def test_no_client(self):
         # no timer client configured; exception expected
+        timer.configure(None)
         with self.assertRaises(RuntimeError):
             with timer.expires(after=1):
                 pass

--- a/test/train_loop_test.py
+++ b/test/train_loop_test.py
@@ -5,22 +5,20 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-import typing
 import unittest
-from dataclasses import dataclass
 
 from torchelastic.train_loop import to_generator
 
 
 class TestTrainLoop(unittest.TestCase):
-    @dataclass
     class MockState:
-        data: typing.Generator[int, None, None]
-        sum: int = 0
+        def __init__(self, range: range):
+            self.data_iter = iter(range)
+            self.sum = 0
 
     @staticmethod
     def _mock_train_step(mock_state):
-        mock_state.sum += next(mock_state.data)
+        mock_state.sum += next(mock_state.data_iter)
 
     @staticmethod
     def _mock_train_step_stop_iteration(mock_state):
@@ -28,7 +26,7 @@ class TestTrainLoop(unittest.TestCase):
 
     def test_to_generator(self):
         r = range(0, 10)
-        mock_state = self.MockState(iter(r))
+        mock_state = self.MockState(r)
 
         for _ in to_generator(self._mock_train_step)(mock_state):
             pass
@@ -37,7 +35,7 @@ class TestTrainLoop(unittest.TestCase):
 
     def test_to_generator_throws_stop_iteration(self):
 
-        mock_state = self.MockState(iter(range(0, 10)))
+        mock_state = self.MockState(range(0, 10))
 
         num_iter = 0
         for _ in to_generator(self._mock_train_step_stop_iteration)(mock_state):

--- a/torchelastic/timer/api.py
+++ b/torchelastic/timer/api.py
@@ -11,12 +11,10 @@ import logging
 import threading
 import time
 from contextlib import contextmanager
-from dataclasses import dataclass
 from inspect import getframeinfo, stack
 from typing import Any, Dict, List, Set
 
 
-@dataclass
 class TimerRequest:
     """
     Data object representing a countdown timer acquisition and release
@@ -29,9 +27,12 @@ class TimerRequest:
     agreed on to uniquely identify a worker.
     """
 
-    worker_id: Any
-    scope_id: str
-    expiration_time: float
+    __slots__ = ["worker_id", "scope_id", "expiration_time"]
+
+    def __init__(self, worker_id: Any, scope_id: str, expiration_time: float):
+        self.worker_id = worker_id
+        self.scope_id = scope_id
+        self.expiration_time = expiration_time
 
     def __eq__(self, other):
         if isinstance(other, TimerRequest):


### PR DESCRIPTION
Summary:
Does two things:
1. adds `test/timer/__init__.py` so that timer tests are picked up by the test suite
2. Uses `__slots__` over `dataclass` since `dataclass` is not supported in python 3.6

Differential Revision: D20108666

