### PR TITLE
Added profiling metrics to agent. Improved metrics api to make it easy to add metrics to the agent

### DIFF
--- a/test/metrics/__init__.py
+++ b/test/metrics/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.abs

--- a/test/metrics/api_test.py
+++ b/test/metrics/api_test.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.abs
+import abc
+import unittest
+
+from torchelastic.metrics.api import (
+    MetricData,
+    MetricHandler,
+    _get_metric_name,
+    configure,
+    prof,
+)
+
+
+def foo_1():
+    pass
+
+
+class TestMetricsHandler(MetricHandler):
+    def __init__(self):
+        self.metric_data = {}
+
+    def emit(self, metric_data: MetricData):
+        self.metric_data[metric_data.name] = metric_data
+
+
+class Parent(abc.ABC):
+    @abc.abstractmethod
+    def func(self):
+        raise NotImplementedError()
+
+    def base_func(self):
+        self.func()
+
+
+class Child(Parent):
+    # need to decorate the implementation not the abstract method!
+    @prof
+    def func(self):
+        pass
+
+
+class MetricsApiTest(unittest.TestCase):
+    def foo_2(self):
+        pass
+
+    @prof
+    def bar(self):
+        pass
+
+    @prof
+    def throw(self):
+        raise RuntimeError()
+
+    @prof(group="torchelastic")
+    def bar2(self):
+        pass
+
+    def test_get_metric_name(self):
+        self.assertEqual("api_test.foo_1", _get_metric_name(foo_1))
+        self.assertEqual("MetricsApiTest.foo_2", _get_metric_name(self.foo_2))
+
+    def test_profile(self):
+        handler = TestMetricsHandler()
+        configure(handler)
+
+        self.bar()
+
+        self.assertEqual(1, handler.metric_data["MetricsApiTest.bar.count"].value)
+        self.assertEqual(1, handler.metric_data["MetricsApiTest.bar.success"].value)
+        self.assertNotIn("MetricsApiTest.bar.failure", handler.metric_data)
+        self.assertIn("MetricsApiTest.bar.duration.ms", handler.metric_data)
+
+        with self.assertRaises(RuntimeError):
+            self.throw()
+
+        self.assertEqual(1, handler.metric_data["MetricsApiTest.throw.count"].value)
+        self.assertEqual(1, handler.metric_data["MetricsApiTest.throw.failure"].value)
+        self.assertNotIn("MetricsApiTest.bar_raise.success", handler.metric_data)
+        self.assertIn("MetricsApiTest.throw.duration.ms", handler.metric_data)
+
+        self.bar2()
+        self.assertEqual(
+            "torchelastic", handler.metric_data["MetricsApiTest.bar2.count"].group_name
+        )
+
+    def test_inheritance(self):
+        handler = TestMetricsHandler()
+        configure(handler)
+
+        c = Child()
+        c.base_func()
+
+        self.assertEqual(1, handler.metric_data["Child.func.count"].value)
+        self.assertEqual(1, handler.metric_data["Child.func.success"].value)
+        self.assertIn("Child.func.duration.ms", handler.metric_data)

--- a/torchelastic/agent/server/local_elastic_agent.py
+++ b/torchelastic/agent/server/local_elastic_agent.py
@@ -17,6 +17,7 @@ from torchelastic.agent.server.api import (
     WorkerSpec,
     WorkerState,
 )
+from torchelastic.metrics.api import prof
 
 
 log = logging.getLogger(__name__)
@@ -85,11 +86,13 @@ class LocalElasticAgent(SimpleElasticAgent):
         self._start_method = start_method
         self._process_context: mp.ProcessContext = None
 
+    @prof
     def _stop_workers(self, worker_group: WorkerGroup) -> None:
         for proc in self._process_context.processes:
             if proc.is_alive():
                 proc.terminate()
 
+    @prof
     def _start_workers(self, worker_group: WorkerGroup) -> Dict[int, Any]:
         spec = worker_group.spec
         store = worker_group.store
@@ -122,6 +125,7 @@ class LocalElasticAgent(SimpleElasticAgent):
             for local_rank, pid in enumerate(self._process_context.pids())
         }
 
+    @prof
     def _monitor_workers(self, worker_group: WorkerGroup) -> WorkerState:
         role = worker_group.spec.role
 

--- a/torchelastic/metrics/api.py
+++ b/torchelastic/metrics/api.py
@@ -8,6 +8,7 @@
 
 import abc
 import time
+import warnings
 from collections import namedtuple
 from functools import wraps
 
@@ -17,12 +18,12 @@ MetricData = namedtuple("MetricData", ["timestamp", "group_name", "name", "value
 
 class MetricHandler(abc.ABC):
     @abc.abstractmethod
-    def emit(self, metric_data):
+    def emit(self, metric_data: MetricData):
         pass
 
 
 class ConsoleMetricHandler(MetricHandler):
-    def emit(self, metric_data):
+    def emit(self, metric_data: MetricData):
         print(
             "[{}][{}]: {}={}".format(
                 metric_data.timestamp,
@@ -34,16 +35,16 @@ class ConsoleMetricHandler(MetricHandler):
 
 
 class NullMetricHandler(MetricHandler):
-    def emit(self, metric_data):
+    def emit(self, metric_data: MetricData):
         pass
 
 
 class MetricStream:
-    def __init__(self, group_name, handler):
+    def __init__(self, group_name: str, handler: MetricHandler):
         self.group_name = group_name
         self.handler = handler
 
-    def add_value(self, metric_name, metric_value):
+    def add_value(self, metric_name: str, metric_value: int):
         self.handler.emit(
             MetricData(time.time(), self.group_name, metric_name, metric_value)
         )
@@ -53,7 +54,7 @@ _metrics_map = {}
 _default_metrics_handler = NullMetricHandler()
 
 
-def configure(handler, group=None):
+def configure(handler: MetricHandler, group: str = None):
     if group is None:
         global _default_metrics_handler
         _default_metrics_handler = handler
@@ -61,12 +62,69 @@ def configure(handler, group=None):
         _metrics_map[group] = handler
 
 
-def getStream(group):
+def getStream(group: str):
     if group in _metrics_map:
         handler = _metrics_map[group]
     else:
         handler = _default_metrics_handler
     return MetricStream(group, handler)
+
+
+def _get_metric_name(fn):
+    qualname = fn.__qualname__
+    split = qualname.split(".")
+    if len(split) == 1:
+        module = fn.__module__
+        if module:
+            return module.split(".")[-1] + "." + split[0]
+        else:
+            return split[0]
+    else:
+        return qualname
+
+
+def prof(fn=None, group: str = None):
+    r"""
+    @profile decorator publishes duration.ms, count, success, failure
+    metrics for the function that it decorates. The metric name defaults
+    to the qualified name (``class_name.def_name``) of the function.
+    If the function does not belong to a class, it uses the leaf module name
+    instead.
+
+    Usage
+
+    ::
+        @metrics.profile
+        def x():
+            pass
+
+        @metrics.profile(group="Foo")
+        def y():
+            pass
+    """
+
+    def wrap(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            key = _get_metric_name(f)
+            publish_metric(group, f"{key}.count", 1)
+            try:
+                start = time.time()
+                result = f(*args, **kwargs)
+                publish_metric(group, f"{key}.success", 1)
+            except Exception:
+                publish_metric(group, f"{key}.failure", 1)
+                raise
+            finally:
+                publish_metric(group, f"{key}.duration.ms", get_elapsed_time_ms(start))
+            return result
+
+        return wrapper
+
+    if fn:
+        return wrap(fn)
+    else:
+        return wrap
 
 
 def profile(group=None):
@@ -78,6 +136,7 @@ def profile(group=None):
         @metrics.profile("my_metric_group")
         def some_function(<arguments>):
     """
+    warnings.warn("Deprecated, use @prof instead", DeprecationWarning)
 
     def wrap(func):
         @wraps(func)
@@ -102,12 +161,12 @@ def profile(group=None):
     return wrap
 
 
-def publish_metric(metric_group, metric_name, metric_value):
+def publish_metric(metric_group: str, metric_name: str, metric_value: int):
     metric_stream = getStream(metric_group)
     metric_stream.add_value(metric_name, metric_value)
 
 
-def get_elapsed_time_ms(start_time_in_seconds):
+def get_elapsed_time_ms(start_time_in_seconds: float):
     """
     Returns the elapsed time in millis from the given start time.
     """


### PR DESCRIPTION
Summary:
1. Added profiling to all major functions in the agent
2. Improved metrics api to make this easier
    a. `prof` works with or without arguments
    b. added unittests for metrics api
    c. added as much typing as possible on the public api defintions
    d. improved automatic metric name assignment from being just the function name to being the qualified function name (`class.func_name` or `module_leaf.func_name`)

Next steps:
1. Configure the metrics handler at the call-site (in the flow launcher) this will actually make the metrics go to ODS (currently the default metrics handler is the null handler which makes the metrics go to `/dev/null`)

Differential Revision: D20578810

