### PR TITLE
Initialize TorchElasticService when starting the agent

### DIFF
--- a/test/metrics/api_test.py
+++ b/test/metrics/api_test.py
@@ -71,7 +71,6 @@ class MetricsApiTest(unittest.TestCase):
 
         self.bar()
 
-        self.assertEqual(1, handler.metric_data["MetricsApiTest.bar.count"].value)
         self.assertEqual(1, handler.metric_data["MetricsApiTest.bar.success"].value)
         self.assertNotIn("MetricsApiTest.bar.failure", handler.metric_data)
         self.assertIn("MetricsApiTest.bar.duration.ms", handler.metric_data)
@@ -79,14 +78,14 @@ class MetricsApiTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.throw()
 
-        self.assertEqual(1, handler.metric_data["MetricsApiTest.throw.count"].value)
         self.assertEqual(1, handler.metric_data["MetricsApiTest.throw.failure"].value)
         self.assertNotIn("MetricsApiTest.bar_raise.success", handler.metric_data)
         self.assertIn("MetricsApiTest.throw.duration.ms", handler.metric_data)
 
         self.bar2()
         self.assertEqual(
-            "torchelastic", handler.metric_data["MetricsApiTest.bar2.count"].group_name
+            "torchelastic",
+            handler.metric_data["MetricsApiTest.bar2.success"].group_name,
         )
 
     def test_inheritance(self):
@@ -96,6 +95,5 @@ class MetricsApiTest(unittest.TestCase):
         c = Child()
         c.base_func()
 
-        self.assertEqual(1, handler.metric_data["Child.func.count"].value)
         self.assertEqual(1, handler.metric_data["Child.func.success"].value)
         self.assertIn("Child.func.duration.ms", handler.metric_data)

--- a/torchelastic/agent/server/api.py
+++ b/torchelastic/agent/server/api.py
@@ -15,7 +15,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, Tuple
 
 import torchelastic.rendezvous as rdzv
-from torchelastic.metrics.api import prof, publish_metric
+from torchelastic.metrics import prof, put_metric
 
 
 DEFAULT_ROLE = "default"
@@ -419,6 +419,9 @@ class SimpleElasticAgent(ElasticAgent):
         while True:
             assert self._worker_group.state != WorkerState.INIT
             time.sleep(monitor_interval)
+            put_metric(
+                f"worker_group.{role}.remaining_restarts", self._remaining_restarts
+            )
 
             state = self._monitor_workers(self._worker_group)
             self._worker_group.state = state
@@ -454,9 +457,3 @@ class SimpleElasticAgent(ElasticAgent):
                     self._restart_workers(self._worker_group)
             else:
                 raise Exception(f"[{role}] Worker group in {state.name} state")
-
-            publish_metric(
-                None,
-                f"worker_group.{role}.remaining_restarts",
-                self._remaining_restarts,
-            )

--- a/torchelastic/distributed/launch.py
+++ b/torchelastic/distributed/launch.py
@@ -162,6 +162,7 @@ from argparse import REMAINDER, ArgumentParser
 
 import torchelastic.rendezvous.etcd_rendezvous  # noqa: F401
 import torchelastic.rendezvous.parameters as parameters
+from torchelastic import metrics
 from torchelastic.agent.server.api import WorkerSpec
 from torchelastic.agent.server.local_elastic_agent import LocalElasticAgent
 
@@ -375,6 +376,7 @@ def main(args=None):
         max_restarts=args.max_restarts,
         monitor_interval=args.monitor_interval,
     )
+    metrics.initialize_metrics()
     elastic_agent = LocalElasticAgent(spec, start_method=args.start_method)
     elastic_agent.run(spec.role)
 

--- a/torchelastic/metrics/__init__.py
+++ b/torchelastic/metrics/__init__.py
@@ -13,8 +13,10 @@ from .api import (  # noqa F401
     configure,
     get_elapsed_time_ms,
     getStream,
+    prof,
     profile,
     publish_metric,
+    put_metric,
 )
 
 


### PR DESCRIPTION
Summary:
This is part 2/2 of wiring up metrics to the agent. Doing a couple of things on this diff:

1. [code deletion] removes un-used supervisor-worker code (this is because there were some inter-dependencies between SW code and metrics API)

2. Add `put_metric()` method to metrics API and deprecate `publish_metric()`

3.  Take out ods entity name building logic from the cpp `TorchElasticService` code out to python land.

4. Add unittest to validate ods entity name building for flow vs no-flow use-cases.

5.  Add `initialize_metrics()` call to `torchelastic.distributed.launch.main` and `pytorch.elastic.torchelastic.distributed.fb.flow_launch.elastic`.

6. Add unittest to validate that `ServiceData` is being populated with metrics.

Differential Revision: D20617216

