### PR TITLE
add group rank to distinfo and env var, made elastic launcher return values from worker fn

### DIFF
--- a/test/agent/server/local_elastic_agent_test.py
+++ b/test/agent/server/local_elastic_agent_test.py
@@ -50,11 +50,16 @@ def _distributed_sum(wait):
         raise RuntimeError(f"Expected rank sum {expected}, got {actual}")
 
 
+def _return_rank_times(a):
+    return int(os.environ["RANK"]) * a
+
+
 def _check_env_function():
     # just check these env vars exist, os.environ[...] will naturally throw
     # if the variable does not exist
     os.environ["RANK"]
     os.environ["LOCAL_RANK"]
+    os.environ["GROUP_RANK"]
     os.environ["WORLD_SIZE"]
     os.environ["MASTER_ADDR"]
     os.environ["MASTER_PORT"]
@@ -146,6 +151,16 @@ class LocalElasticAgentTest(unittest.TestCase):
         spec = self._get_worker_spec(fn=_check_env_function, max_restarts=2)
         agent = LocalElasticAgent(spec, start_method="fork")
         agent.run()
+
+    def test_get_worker_return_values(self):
+        spec = self._get_worker_spec(fn=_return_rank_times, args=(2,))
+        agent = LocalElasticAgent(spec, start_method="fork")
+        agent.run()
+        ret_vals = agent.get_worker_return_values()
+
+        self.assertEqual(spec.local_world_size, len(ret_vals))
+        for i in range(spec.local_world_size):
+            self.assertEqual(i * 2, ret_vals[i])
 
     def test_double_agent_happy(self):
         host = self._etcd_server.get_host()

--- a/torchelastic/agent/server/api.py
+++ b/torchelastic/agent/server/api.py
@@ -197,6 +197,52 @@ class WorkerGroup:
         self.state = WorkerState.INIT
 
 
+class MonitorResult:
+    """
+    Returned by the agent's ``_monitor_workers`` API. A holder object
+    that holds information about the monitoring results.
+    The ``ret_vals`` and ``exceptions`` field map each worker's
+    return value (output) and exceptions (if any) accordingly by
+    the workers global rank.
+
+    ``state = SUCCEEDED`` will have ``ret_val``.
+    ``state = FAILED`` will have ``exceptions``.
+    For other states both these fields will be empty.
+    """
+
+    __slots__ = ["state", "ret_vals", "exceptions"]
+
+    def __init__(
+        self,
+        state: WorkerState,
+        ret_vals: Dict[int, Any] = None,
+        exceptions: Dict[int, Exception] = None,
+    ):
+        self.state = state
+        self.ret_vals = ret_vals
+        self.exceptions = exceptions
+
+
+class WorkerGroupFailureException(Exception):
+    """
+    Thrown when the agent cannot or has given up trying to run the workers.
+    This is typically thrown:
+
+    1. Exceeded ``max_restarts``.
+    2. Workers fail with errors that are deemed ``NonRestartable``
+
+    When constructing this exception the underlying worker exceptions
+    are provided as a map of the worker's global rank to the exception.
+    """
+
+    def __init__(self, msg: str, worker_excs: Dict[int, Exception]):
+        super().__init__(msg)
+        self._worker_excs = worker_excs
+
+    def get_worker_exceptions(self) -> Dict[int, Exception]:
+        return self._worker_excs
+
+
 def _get_socket_with_port() -> socket.socket:
     """
     Returns a free port on localhost that is "reserved" by binding a temporary
@@ -242,12 +288,18 @@ class ElasticAgent(abc.ABC):
     """
 
     @abc.abstractmethod
-    def run(self, role: str = DEFAULT_ROLE) -> None:
+    def run(self, role: str = DEFAULT_ROLE) -> Dict[int, Any]:
         """
-        Runs the agent, retrying the worker group on failures.
+        Runs the agent, retrying the worker group on failures up to
+        ``max_restarts``.
+
+        Returns:
+            The return values for each worker mapped by the worker's global rank.
+            Empty if workers have void signature.
 
         Raises:
-            Exception - ``spec.max_restarts`` has been exceeded
+            WorkerGroupFailureException - workers did not successfully run
+            Exception - any other failures NOT related to worker process
         """
         raise NotImplementedError()
 
@@ -299,7 +351,7 @@ class SimpleElasticAgent(ElasticAgent):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def _monitor_workers(self, worker_group: WorkerGroup) -> WorkerState:
+    def _monitor_workers(self, worker_group: WorkerGroup) -> MonitorResult:
         r"""
         Checks on the workers for the ``worker_group`` and returns
         the new state of the worker group.
@@ -394,7 +446,6 @@ class SimpleElasticAgent(ElasticAgent):
 
         worker_group.state = WorkerState.HEALTHY
 
-    # TODO (T64139987) handle exceptions thrown by the body of this method
     @prof
     def _restart_workers(self, worker_group: WorkerGroup) -> None:
         """
@@ -407,7 +458,7 @@ class SimpleElasticAgent(ElasticAgent):
         worker_group.state = WorkerState.STOPPED
         self._initialize_workers(worker_group)
 
-    def run(self, role: str = DEFAULT_ROLE) -> None:
+    def run(self, role: str = DEFAULT_ROLE) -> Dict[int, Any]:
         # NOTE: currently only works for a single role
 
         spec = self._worker_group.spec
@@ -423,12 +474,13 @@ class SimpleElasticAgent(ElasticAgent):
                 f"worker_group.{role}.remaining_restarts", self._remaining_restarts
             )
 
-            state = self._monitor_workers(self._worker_group)
+            monitor_result = self._monitor_workers(self._worker_group)
+            state = monitor_result.state
             self._worker_group.state = state
 
             if state == WorkerState.SUCCEEDED:
                 log.info(f"[{role}] All workers successfully finished.")
-                return
+                return monitor_result.ret_vals
             elif state in {WorkerState.UNHEALTHY, WorkerState.FAILED}:
                 if self._remaining_restarts > 0:
                     log.info(
@@ -441,8 +493,9 @@ class SimpleElasticAgent(ElasticAgent):
                 else:
                     self._stop_workers(self._worker_group)
                     self._worker_group.state = WorkerState.FAILED
-                    raise Exception(
-                        f"[{role}] no remaining restarts, stopping worker group"
+                    raise WorkerGroupFailureException(
+                        f"[{role}] exceeded max_restarts={spec.max_restarts}",
+                        monitor_result.exceptions,
                     )
             elif state == WorkerState.HEALTHY:
                 # membership changes do not count as retries

--- a/torchelastic/agent/server/local_elastic_agent.py
+++ b/torchelastic/agent/server/local_elastic_agent.py
@@ -12,7 +12,9 @@ from typing import Any, Dict
 
 import torch.multiprocessing as mp
 from torchelastic.agent.server.api import (
+    MonitorResult,
     SimpleElasticAgent,
+    Worker,
     WorkerGroup,
     WorkerSpec,
     WorkerState,
@@ -33,6 +35,7 @@ class _DistInfo:
 
     __slots__ = [
         "rank",
+        "group_rank",
         "world_size",
         "master_addr",
         "master_port",
@@ -43,6 +46,7 @@ class _DistInfo:
     def __init__(
         self,
         rank: int,
+        group_rank: int,
         world_size: int,
         master_addr: str,
         master_port: int,
@@ -50,6 +54,7 @@ class _DistInfo:
         max_restarts: int,
     ):
         self.rank = rank
+        self.group_rank = group_rank
         self.world_size = world_size
         self.master_addr = master_addr
         self.master_port = master_port
@@ -57,16 +62,18 @@ class _DistInfo:
         self.max_restarts = max_restarts
 
 
-def _wrap(local_rank, dist_infos, fn, args):
+def _wrap(local_rank, ret_vals, dist_infos, fn, args):
     info = dist_infos[local_rank]
     os.environ["LOCAL_RANK"] = str(local_rank)
     os.environ["RANK"] = str(info.rank)
+    os.environ["GROUP_RANK"] = str(info.group_rank)
     os.environ["WORLD_SIZE"] = str(info.world_size)
     os.environ["MASTER_ADDR"] = info.master_addr
     os.environ["MASTER_PORT"] = str(info.master_port)
     os.environ["TORCHELASTIC_RESTART_COUNT"] = str(info.restart_count)
     os.environ["TORCHELASTIC_MAX_RESTARTS"] = str(info.max_restarts)
-    fn(*args)
+    ret = fn(*args)
+    ret_vals[info.rank] = ret
 
 
 class LocalElasticAgent(SimpleElasticAgent):
@@ -85,6 +92,12 @@ class LocalElasticAgent(SimpleElasticAgent):
         super().__init__(spec)
         self._start_method = start_method
         self._process_context: mp.ProcessContext = None
+        # a map that holds return values for each worker fn
+        # ret_val[0] holds the return value for worker_0 (global rank 0)
+        self._manager = mp.get_context(start_method).Manager()
+        self._ret_vals: Dict[int, Any] = self._manager.dict()
+        # set by _monitor_workers upon detecting that the worker group is FAILED
+        self._workers_failure_exc: Exception = None
 
     @prof
     def _stop_workers(self, worker_group: WorkerGroup) -> None:
@@ -104,6 +117,7 @@ class LocalElasticAgent(SimpleElasticAgent):
             local_rank = worker.local_rank
             dist_infos[local_rank] = _DistInfo(
                 worker.global_rank,
+                worker_group.group_rank,
                 worker.world_size,
                 master_addr,
                 master_port,
@@ -111,9 +125,10 @@ class LocalElasticAgent(SimpleElasticAgent):
                 spec.max_restarts,
             )
 
+        self._ret_vals.clear()
         self._process_context = mp.start_processes(
             fn=_wrap,
-            args=(dist_infos, spec.fn, spec.args),
+            args=(self._ret_vals, dist_infos, spec.fn, spec.args),
             nprocs=spec.local_world_size,
             join=False,
             daemon=False,
@@ -126,7 +141,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         }
 
     @prof
-    def _monitor_workers(self, worker_group: WorkerGroup) -> WorkerState:
+    def _monitor_workers(self, worker_group: WorkerGroup) -> MonitorResult:
         role = worker_group.spec.role
 
         # torch process context join() isn't really a join in the
@@ -134,20 +149,25 @@ class LocalElasticAgent(SimpleElasticAgent):
         # successfully finished, False if some/all are still running
         # and throws an Exception if some/all of them failed
         # passing timeout < 0 means check worker status and return immediately
-        state = worker_group.state
+
         worker_pids = {w.id for w in worker_group.workers}
         pc_pids = set(self._process_context.pids())
         if worker_pids != pc_pids:
             log.error(f"[{role}] worker pids do not match process_context pids")
-            return WorkerState.UNKNOWN
+            return MonitorResult(WorkerState.UNKNOWN)
 
         try:
             if self._process_context.join(timeout=-1):
-                state = WorkerState.SUCCEEDED
+                ret_vals: Dict[Worker, Any] = {}
+                # remap from global_rank -> ret_val to worker -> ret_val
+                for w in worker_group.workers:
+                    ret_vals[w] = self._ret_vals[w.global_rank]
+                return MonitorResult(WorkerState.SUCCEEDED, ret_vals)
             else:
-                state = WorkerState.HEALTHY
+                return MonitorResult(WorkerState.HEALTHY)
         except Exception as e:
-            log.error(f"[{role}] Worker set failed", exc_info=e)
-            state = WorkerState.FAILED
-
-        return state
+            log.exception(f"[{role}] Worker group failed")
+            return MonitorResult(
+                WorkerState.FAILED,
+                exceptions={w.global_rank: e for w in worker_group.workers},
+            )


### PR DESCRIPTION
Summary:
1. add group rank (a.k.a node_index) to exported env var in local agent
2. added `get_worker_return_values()` function to the agent api
3. modified local agent to return worker ret_vals (mapped by global rank)
4. modified `elastic_launch` to return all the ret_vals for all the workers

NOTE: this is a requirement for making flow launchers work with flow operators since operators can have outputs which are consumed from the workflow (or downstream operators).

Differential Revision: D20642735

