### PR TITLE
Made elastic_launch an operator

### DIFF
--- a/torchelastic/agent/server/api.py
+++ b/torchelastic/agent/server/api.py
@@ -463,6 +463,9 @@ class SimpleElasticAgent(ElasticAgent):
 
         spec = self._worker_group.spec
         role = spec.role
+
+        log.info(f"[{role}] starting workers for function: {spec.fn.__name__}")
+
         self._initialize_workers(self._worker_group)
         monitor_interval = spec.monitor_interval
         rdzv_handler = spec.rdzv_handler


### PR DESCRIPTION
Summary:
Fixes:
1. Gang name -> `elastic-gang:<fn_name>`
2. Made default start method for LaunchConfig == `spawn`
3. Made `launch_elastic` work with regular python functions (removes `elastic` decorator)

TODO:
1. `elastic_operator` for some reason is not being run and hence we get a `MissingData` error when trying to merge the return values.

Differential Revision: D20686552

