### PR TITLE
torchelastic: enable pyre

### DIFF
--- a/examples/classy_vision/main.py
+++ b/examples/classy_vision/main.py
@@ -24,6 +24,8 @@ from classy_vision.hooks import (
     TimeMetricsHook,
 )
 from classy_vision.tasks import FineTuningTask, build_task
+
+# pyre-fixme[21]: Could not find `elastic_trainer`.
 from classy_vision.trainer.elastic_trainer import ElasticTrainer
 from torch.distributed import Backend
 from torchelastic.p2p import CoordinatorP2P

--- a/examples/imagenet/main.py
+++ b/examples/imagenet/main.py
@@ -282,6 +282,8 @@ def train_step(state: ImagenetState):
     """
 
     start = time.time()
+    # pyre-fixme[23]: Unable to unpack `_T` into 2 values.
+    # pyre-fixme[16]: `ImagenetState` has no attribute `data_iter`.
     input, target = next(state.data_iter)
 
     # This is needed because the world size may change between iterations
@@ -290,8 +292,10 @@ def train_step(state: ImagenetState):
     adjust_learning_rate(
         world_size,
         state.params,
+        # pyre-fixme[16]: `ImagenetState` has no attribute `optimizer`.
         state.optimizer,
         state.epoch,
+        # pyre-fixme[16]: `ImagenetState` has no attribute `data_loader`.
         len(state.data_loader),
         state.iteration,
     )
@@ -301,7 +305,9 @@ def train_step(state: ImagenetState):
     target_var = torch.autograd.Variable(target)
 
     # Compute output
+    # pyre-fixme[16]: `ImagenetState` has no attribute `dist_model`.
     output = state.dist_model(input_var)
+    # pyre-fixme[16]: `ImagenetState` has no attribute `criterion`.
     loss = state.criterion(output, target_var)
 
     # Compute gradient and do SGD step

--- a/test/agent/server/api_test.py
+++ b/test/agent/server/api_test.py
@@ -97,6 +97,8 @@ class TestAgent(SimpleElasticAgent):
         self.start_workers_call_count += 1
         return ids
 
+    # pyre-fixme[15]: `_monitor_workers` overrides method defined in
+    #  `SimpleElasticAgent` inconsistently.
     def _monitor_workers(self, worker_group: WorkerGroup) -> WorkerState:
         raise NotImplementedError("mock this method")
 

--- a/test/distributed/collectives_test.py
+++ b/test/distributed/collectives_test.py
@@ -23,6 +23,8 @@ log = logging.getLogger(__name__)
 
 
 def compute_checksum(data: np.ndarray) -> bytes:
+    # pyre-fixme[6]: Expected `Union[bytearray, bytes, memoryview]` for 1st param
+    #  but got `ndarray`.
     return md5(data).hexdigest().encode("utf-8")
 
 

--- a/torchelastic/agent/server/api.py
+++ b/torchelastic/agent/server/api.py
@@ -115,10 +115,12 @@ class Worker:
         #  rank of the worker among all the workers with the same role
         #  across all ``agent`` instances.
         #  Global rank is not stable between re-rendezvous.
+        # pyre-fixme[8]: Attribute has type `int`; used as `None`.
         self.global_rank: int = None
 
         # total number of workers (globally). Due to elasticity
         # the world size may change between re-rendezvous.
+        # pyre-fixme[8]: Attribute has type `int`; used as `None`.
         self.world_size: int = None
 
 
@@ -214,10 +216,13 @@ class MonitorResult:
     def __init__(
         self,
         state: WorkerState,
+        # pyre-fixme[9]: ret_vals has type `Dict[int, typing.Any]`; used as `None`.
         ret_vals: Dict[int, Any] = None,
+        # pyre-fixme[9]: exceptions has type `Dict[int, Exception]`; used as `None`.
         exceptions: Dict[int, Exception] = None,
     ):
         self.state = state
+        # pyre-fixme[8]: Attribute has type `Dict[int, typing.Any]`; used as `None`.
         self.ret_vals = ret_vals
         self.exceptions = exceptions
 
@@ -259,6 +264,7 @@ def _get_socket_with_port() -> socket.socket:
         func(port)
     """
 
+    # pyre-fixme[28]: Unexpected keyword argument `type`.
     addrs = socket.getaddrinfo(
         host="localhost", port=None, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM
     )
@@ -354,6 +360,8 @@ class SimpleElasticAgent(ElasticAgent):
         self._worker_group = WorkerGroup(spec)
         self._remaining_restarts = self._worker_group.spec.max_restarts
 
+    # pyre-fixme[14]: `get_worker_group` overrides method defined in `ElasticAgent`
+    #  inconsistently.
     def get_worker_group(self) -> WorkerGroup:
         # TODO return an RO copy (need to create an ROWorkerGroup and ROWorkerSpec
         # since both these classes contain non-pure-data pointers - e.g. rdzv_handler)

--- a/torchelastic/agent/server/local_elastic_agent.py
+++ b/torchelastic/agent/server/local_elastic_agent.py
@@ -116,6 +116,7 @@ class LocalElasticAgent(SimpleElasticAgent):
     def __init__(self, spec: WorkerSpec, start_method="spawn"):
         super().__init__(spec)
         self._start_method = start_method
+        # pyre-fixme[8]: Attribute has type `ProcessContext`; used as `None`.
         self._process_context: mp.ProcessContext = None
         # a map that holds return values for each worker fn
         # ret_val[0] holds the return value for worker_0 (global rank 0)

--- a/torchelastic/metrics/api.py
+++ b/torchelastic/metrics/api.py
@@ -54,9 +54,12 @@ _metrics_map = {}
 _default_metrics_handler = NullMetricHandler()
 
 
+# pyre-fixme[9]: group has type `str`; used as `None`.
 def configure(handler: MetricHandler, group: str = None):
     if group is None:
         global _default_metrics_handler
+        # pyre-fixme[9]: _default_metrics_handler has type `NullMetricHandler`; used
+        #  as `MetricHandler`.
         _default_metrics_handler = handler
     else:
         _metrics_map[group] = handler

--- a/torchelastic/rendezvous/api.py
+++ b/torchelastic/rendezvous/api.py
@@ -52,6 +52,7 @@ class RendezvousHandler(abc.ABC):
     """
 
     @abc.abstractmethod
+    # pyre-fixme[11]: Annotation `Store` is not defined as a type.
     def next_rendezvous(self) -> Tuple["torch.distributed.Store", int, int]:
         """
         Main entry-point into the rendezvous barrier.

--- a/torchelastic/rendezvous/etcd_rendezvous.py
+++ b/torchelastic/rendezvous/etcd_rendezvous.py
@@ -918,6 +918,7 @@ class EtcdRendezvous(object):
         return EtcdStore(etcd_client=self.client, etcd_store_prefix=store_path)
 
 
+# pyre-fixme[11]: Annotation `Store` is not defined as a type.
 class EtcdStore(Store):
     """
     Implements a c10 Store interface by piggybacking on the rendezvous etcd instance.

--- a/torchelastic/timer/api.py
+++ b/torchelastic/timer/api.py
@@ -217,6 +217,7 @@ class TimerServer(abc.ABC):
             target=self._watchdog_loop, daemon=self._daemon
         )
         logging.info(f"Starting watchdog thread...")
+        # pyre-fixme[16]: Optional type has no attribute `start`.
         self._watchdog_thread.start()
 
     def stop(self) -> None:
@@ -224,6 +225,7 @@ class TimerServer(abc.ABC):
         self._stop_signaled = True
         if self._watchdog_thread:
             logging.info(f"Stopping watchdog thread...")
+            # pyre-fixme[16]: Optional type has no attribute `join`.
             self._watchdog_thread.join(self._max_interval)
             self._watchdog_thread = None
         else:
@@ -243,6 +245,8 @@ def configure(timer_client: TimerClient):
 
 
 @contextmanager
+# pyre-fixme[9]: scope has type `str`; used as `None`.
+# pyre-fixme[9]: client has type `TimerClient`; used as `None`.
 def expires(after: float, scope: str = None, client: TimerClient = None) -> None:
     """
     Acquires a countdown timer that expires in ``after`` seconds from now,
@@ -264,6 +268,7 @@ def expires(after: float, scope: str = None, client: TimerClient = None) -> None
     if client is None:
         if _timer_client is None:
             raise RuntimeError("Configure timer client before using coundown timers.")
+        # pyre-fixme[9]: client has type `TimerClient`; used as `None`.
         client = _timer_client
     if scope is None:
         # grab the caller file + lineno
@@ -272,6 +277,7 @@ def expires(after: float, scope: str = None, client: TimerClient = None) -> None
     expiration = time.time() + after
     client.acquire(scope, expiration)
     try:
+        # pyre-fixme[7]: Expected `None` but got `Generator[None, None, None]`.
         yield
     finally:
         client.release(scope)


### PR DESCRIPTION
Summary:
This enables pyre for pytorch/torchelastic. Pyre is a static type checker that ensures that the specified types are correct as well as able to catch a number of bugs related to missing variables, imports, etc.

Any existing errors have been annotated with `# pyre-fixme`

```
pyre init --local
pyre --output=json -l dir check | pyre-upgrade fixme
arc lint
```

Reviewed By: kiukchung

Differential Revision: D20822623

