### PR TITLE
remove usage of deprecated use_env flag in new launch tests introduced in D20658603

### DIFF
--- a/test/distributed/launch_test.py
+++ b/test/distributed/launch_test.py
@@ -115,7 +115,7 @@ class LaunchTest(unittest.TestCase):
 
         script_args = [path("bin/test_script.sh"), f"{self.test_dir}"]
 
-        launch.main(args + ["--use_env"] + script_args)
+        launch.main(args + script_args)
 
         world_size = nnodes * expected_number
         # make sure all the workers ran


### PR DESCRIPTION
Summary:
See history of `launch_test.py` here:
https://our.intern.facebook.com/intern/diffusion/FBS/history/master/fbcode/pytorch/elastic/test/distributed/launch_test.py

Both D20884230 and D20658603 modified `launch_test` but different lines, so the merge driver seemed to have just "merged" the two commits rather than showing a conflict and asking the user to manually merge.

What is strange was that landcastle let me land D20884230 with breaking tests...

Differential Revision: D20894330

