### PR TITLE
fix circleci test breakage by not using UNSET_RPC_TIMEOUT constant

### DIFF
--- a/examples/bin/install_etcd
+++ b/examples/bin/install_etcd
@@ -6,6 +6,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+set -e
+
 usage() { echo "Usage: $0 [-v <etcd ver>] [-d <install bin dir>]"; exit 2; }
 
 ETCD_VER="v3.4.3"
@@ -22,14 +24,15 @@ done
 echo "Installing etcd ${ETCD_VER} to ${BIN_DIR}"
 
 BASE_DOWNLOAD_URL=https://github.com/etcd-io/etcd/releases/download
-DOWNLOAD_URL="${BASE_DOWNLOAD_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-amd64.tar.gz"
+ETCD_TAR_NAME="etcd-${ETCD_VER}-linux-amd64.tar.gz"
+DOWNLOAD_URL="${BASE_DOWNLOAD_URL}/${ETCD_VER}/${ETCD_TAR_NAME}"
 
 TMP_DIR="/tmp/etcd-${ETCD_VER}"
 rm -rf "${TMP_DIR}" && mkdir -p "${TMP_DIR}"
 
 echo "Downloading pre-built binary from ${DOWNLOAD_URL}"
-curl -L "${DOWNLOAD_URL}" -o "${TMP_DIR}/etcd-${ETCD_VER}-linux-amd64.tar.gz"
-tar xzf "${TMP_DIR}/etcd-${ETCD_VER}-linux-amd64.tar.gz" -C "${TMP_DIR}" --strip-components=1
+wget "${DOWNLOAD_URL}" -O "${TMP_DIR}/${ETCD_TAR_NAME}"
+tar xzf "${TMP_DIR}/${ETCD_TAR_NAME}" -C "${TMP_DIR}" --strip-components=1
 
 mkdir -p "${BIN_DIR}"
 cp -p "${TMP_DIR}/etcd" "${BIN_DIR}"

--- a/torchelastic/distributed/rpc/api.py
+++ b/torchelastic/distributed/rpc/api.py
@@ -9,7 +9,6 @@
 from typing import Any, Dict, Iterable
 
 import torch.distributed.rpc as torch_rpc
-from torch.distributed.rpc.constants import UNSET_RPC_TIMEOUT
 
 
 class WorkerInfo:
@@ -110,7 +109,7 @@ def wait_all(futures):
 
 
 def rpc_sync_on_role(
-    role: str, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT
+    role: str, func, args=None, kwargs=None, timeout=None
 ) -> Dict[str, Any]:
     # TODO placeholder; implement
     futs = rpc_async_on_role(role, func, args, kwargs, timeout)
@@ -118,8 +117,13 @@ def rpc_sync_on_role(
 
 
 def rpc_async_on_role(
-    role: str, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT
+    role: str, func, args=None, kwargs=None, timeout=None
 ) -> Dict[str, torch_rpc.Future]:
+    # can't use rpc.UNSET_RPC_TIMEOUT (only available in torch 1.6.0+)
+    # reproduce the same behavior by getting the timeout if one is not passed
+    if timeout is None:
+        timeout = torch_rpc.get_rpc_timeout()
+
     futures = {}
     for name in get_worker_names(role):
         fut = torch_rpc.rpc_async(name, func, args, kwargs, timeout)


### PR DESCRIPTION
Summary: `UNSET_RPC_TIMEOUT` is NOT available in torch 1.5.0. Remove this dependency and instead replicate the behavior by explicitly calling `rpc.get_rpc_timeout()` if one is not passed to `rpc_async()` and `rpc_sync()`

Differential Revision: D21676757

