### PR TITLE
Fix typo in torchelastic multi-container tutorials

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -122,7 +122,7 @@ To start the example, run
 
 ::
 
-   cd $TORCHELATIC_HOME/examples/multi_container && docker-compose up
+   cd $TORCHELASTIC_HOME/examples/multi_container && docker-compose up
 
 You should see two sets of outputs, one from ETCD starting up and one
 from the application itself. The output from the application looks

--- a/examples/multi_container/README.md
+++ b/examples/multi_container/README.md
@@ -44,7 +44,7 @@ This example uses `docker-compose` to run two containers: one for the ETCD servi
 
 To start the example, run
 ```
-cd $TORCHELATIC_HOME/examples/multi_container && docker-compose up
+cd $TORCHELASTIC_HOME/examples/multi_container && docker-compose up
 ```
 You should see two sets of outputs, one from ETCD starting up and one from the application itself. The output from the application looks something like this:
 


### PR DESCRIPTION
Summary: Found this while validating the new Classy Vision/PET tutorials

Reviewed By: kiukchung

Differential Revision: D21687358

