### PR TITLE
expose run_id as TORCHELASTIC_RUN_ID env var for workers

### DIFF
--- a/test/agent/server/local_elastic_agent_test.py
+++ b/test/agent/server/local_elastic_agent_test.py
@@ -88,6 +88,7 @@ def _check_env_function():
     os.environ["MASTER_PORT"]
     os.environ["TORCHELASTIC_RESTART_COUNT"]
     os.environ["TORCHELASTIC_MAX_RESTARTS"]
+    os.environ["TORCHELASTIC_RUN_ID"]
 
 
 def _run_agent(
@@ -136,6 +137,12 @@ class LocalElasticAgentTest(unittest.TestCase):
         # stop the standalone etcd server
         cls._etcd_server.stop()
 
+    @unittest.skipIf(is_tsan(), "test incompatible with tsan")
+    def test_run_happy_function(self):
+        spec = self._get_worker_spec(fn=_happy_function)
+        agent = LocalElasticAgent(spec, start_method="fork")
+        agent.run()
+
     def _get_worker_spec(
         self,
         fn,
@@ -161,12 +168,6 @@ class LocalElasticAgentTest(unittest.TestCase):
             monitor_interval=monitor_interval,
         )
         return spec
-
-    @unittest.skipIf(is_tsan(), "test incompatible with tsan")
-    def test_run_happy_function(self):
-        spec = self._get_worker_spec(fn=_happy_function)
-        agent = LocalElasticAgent(spec, start_method="fork")
-        agent.run()
 
     @unittest.skipIf(is_tsan(), "test incompatible with tsan")
     def test_run_distributed_sum(self):
@@ -330,6 +331,17 @@ class LocalElasticAgentTest(unittest.TestCase):
         spec = self._get_worker_spec(fn=_check_env_function, max_restarts=2)
         agent = LocalElasticAgent(spec, start_method="fork")
         agent.run()
+
+    def test_run_check_run_id(self):
+        def return_run_id():
+            return os.environ["TORCHELASTIC_RUN_ID"]
+
+        spec = self._get_worker_spec(fn=return_run_id, max_restarts=0)
+        agent = LocalElasticAgent(spec, start_method="fork")
+        ret = agent.run()
+
+        for i in range(spec.local_world_size):
+            self.assertEqual(spec.rdzv_handler.get_run_id(), ret[i])
 
     @unittest.skipIf(is_tsan(), "test incompatible with tsan")
     def test_get_worker_return_values(self):

--- a/torchelastic/agent/server/local_elastic_agent.py
+++ b/torchelastic/agent/server/local_elastic_agent.py
@@ -44,6 +44,7 @@ class _DistInfo:
         "master_port",
         "restart_count",
         "max_restarts",
+        "run_id",
     ]
 
     def __init__(
@@ -58,6 +59,7 @@ class _DistInfo:
         master_port: int,
         restart_count: int,
         max_restarts: int,
+        run_id: str,
     ):
         self.rank = rank
         self.group_rank = group_rank
@@ -69,6 +71,7 @@ class _DistInfo:
         self.master_port = master_port
         self.restart_count = restart_count
         self.max_restarts = max_restarts
+        self.run_id = run_id
 
 
 def _wrap(local_rank, ret_vals, dist_infos, fn, args):
@@ -84,6 +87,7 @@ def _wrap(local_rank, ret_vals, dist_infos, fn, args):
     os.environ["MASTER_PORT"] = str(info.master_port)
     os.environ["TORCHELASTIC_RESTART_COUNT"] = str(info.restart_count)
     os.environ["TORCHELASTIC_MAX_RESTARTS"] = str(info.max_restarts)
+    os.environ["TORCHELASTIC_RUN_ID"] = info.run_id
     ret = fn(*args)
     ret_vals[info.rank] = ret
 
@@ -163,6 +167,7 @@ class LocalElasticAgent(SimpleElasticAgent):
                 master_port,
                 restart_count,
                 spec.max_restarts,
+                spec.rdzv_handler.get_run_id(),
             )
 
         self._ret_vals.clear()

--- a/torchelastic/distributed/launch.py
+++ b/torchelastic/distributed/launch.py
@@ -132,6 +132,8 @@ script:
 
 11. ``TORCHELASTIC_MAX_RESTARTS`` - configured max number of restarts.
 
+12. ``TORCHELASTIC_RUN_ID`` - equal to rdzv run_id (e.g. unique job id).
+
 **Deployment:**
 
 1. Start the rdzv backend server and get the endpoint


### PR DESCRIPTION
Summary: run_id is a unique id for the run instance of the job. It is useful for the workers to have access to this information for various purposes. For instance it serves a a prefix for a directory that local rank 0 creates that would not collide with other jobs that are stacked on the same node.

Differential Revision: D22104173

