### PR TITLE
enable fault handler to dump python traceback on error signals

### DIFF
--- a/torchelastic/agent/server/local_elastic_agent.py
+++ b/torchelastic/agent/server/local_elastic_agent.py
@@ -75,6 +75,10 @@ class _DistInfo:
 
 
 def _wrap(local_rank, ret_vals, dist_infos, fn, args):
+    import faulthandler
+
+    faulthandler.enable(all_threads=True)
+
     info = dist_infos[local_rank]
     os.environ["LOCAL_RANK"] = str(local_rank)
     os.environ["RANK"] = str(info.rank)


### PR DESCRIPTION
Summary: Without this, there is no stack trace in the logs if the worker function faults with a signal (rather than an exception). See https://fb.workplace.com/groups/319878845696681/permalink/2698728570401216/ for more details.

Differential Revision: D22229150

