### PR TITLE
initial api skeleton

### DIFF
--- a/test/tsm/driver/__init__.py
+++ b/test/tsm/driver/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/tsm/driver/api_test.py
+++ b/test/tsm/driver/api_test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import unittest
+from typing import Dict, Optional
+
+from torchelastic.tsm.driver.api import (
+    _TERMINAL_STATES,
+    Application,
+    AppState,
+    AppStatus,
+    Container,
+    Resources,
+    Role,
+    RunMode,
+    Session,
+)
+
+
+class ApplicationStatusTest(unittest.TestCase):
+    def test_is_terminal(self):
+        for s in AppState:
+            is_terminal = AppStatus(state=s).is_terminal()
+            if s in _TERMINAL_STATES:
+                self.assertTrue(is_terminal)
+            else:
+                self.assertFalse(is_terminal)
+
+
+class RoleBuilderTest(unittest.TestCase):
+    def test_build_role(self):
+        # runs: ENV_VAR_1=FOOBAR /bin/echo hello world
+        container = Container(image="test_image")
+        container.ports(foo=8080)
+        trainer = (
+            Role("trainer")
+            .runs("/bin/echo", "hello", "world", ENV_VAR_1="FOOBAR")
+            .on(container)
+            .replicas(2)
+        )
+
+        self.assertEqual("trainer", trainer.name)
+        self.assertEqual("/bin/echo", trainer.entrypoint)
+        self.assertEqual({"ENV_VAR_1": "FOOBAR"}, trainer.env)
+        self.assertEqual(["hello", "world"], trainer.args)
+        self.assertEqual(container, trainer.container)
+        self.assertEqual(2, trainer.num_replicas)
+
+
+class ApplicationTest(unittest.TestCase):
+    def test_application(self):
+        container = Container(image="test_image")
+        trainer = Role("trainer").runs("/bin/sleep", "10").on(container).replicas(2)
+        app = Application(name="test_app").of(trainer)
+        self.assertEqual("test_app", app.name)
+        self.assertEqual(1, len(app.roles))
+        self.assertEqual(trainer, app.roles[0])
+        self.assertEqual(RunMode.HEADLESS, app.run_mode)
+
+    def test_application_default(self):
+        app = Application(name="test_app")
+        self.assertEqual(RunMode.HEADLESS, app.run_mode)
+        self.assertEqual(0, len(app.roles))
+        self.assertFalse(app.is_attached)
+
+
+class SessionTest(unittest.TestCase):
+    class MockSession(Session):
+        def __init__(self):
+            super().__init__("mock session")
+
+        def _run(self, app: Application, mode: RunMode = RunMode.HEADLESS) -> str:
+            return app.name
+
+        def status(self, app_id: str) -> Optional[AppStatus]:
+            return None
+
+        def wait(self, app_id: str) -> Optional[AppStatus]:
+            return None
+
+        def list(self) -> Dict[str, Application]:
+            return {}
+
+        def stop(self, app_id: str) -> None:
+            pass
+
+        def attach(self, app_id: str) -> Application:
+            return Application(app_id)
+
+    def test_validate_no_roles(self):
+        session = self.MockSession()
+        with self.assertRaises(ValueError):
+            app = Application("no roles")
+            session.run(app)
+
+    def test_validate_no_container(self):
+        session = self.MockSession()
+        with self.assertRaises(ValueError):
+            role = Role("no container").runs("echo", "hello_world")
+            app = Application("no container").of(role)
+            session.run(app)
+
+    def test_validate_no_resource(self):
+        session = self.MockSession()
+        with self.assertRaises(ValueError):
+            container = Container("no resource")
+            role = Role("no resource").runs("echo", "hello_world").on(container)
+            app = Application("no resource").of(role)
+            session.run(app)
+
+    def test_validate_invalid_replicas(self):
+        session = self.MockSession()
+        with self.assertRaises(ValueError):
+            container = Container("torch").require(Resources(cpu=1, gpu=0, memMB=500))
+            role = (
+                Role("no container")
+                .runs("echo", "hello_world")
+                .on(container)
+                .replicas(0)
+            )
+            app = Application("no container").of(role)
+            session.run(app)

--- a/test/tsm/driver/local_scheduler_test.py
+++ b/test/tsm/driver/local_scheduler_test.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from torchelastic.tsm.driver.api import Application, AppState, Container, Role, RunMode
+from torchelastic.tsm.driver.local_scheduler import (
+    LocalDirectoryImageFetcher,
+    LocalScheduler,
+)
+
+from .test_util import write_shell_script
+
+
+class LocalDirImageFetcherTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix="LocalDirImageFetcherTest")
+        self.test_dir_name = os.path.basename(self.test_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_fetch_abs_path(self):
+        fetcher = LocalDirectoryImageFetcher()
+        self.assertEqual(self.test_dir, fetcher.fetch(self.test_dir))
+
+    def test_fetch_relative_path_should_throw(self):
+        fetcher = LocalDirectoryImageFetcher()
+        with self.assertRaises(ValueError):
+            fetcher.fetch(self.test_dir_name)
+
+    def test_fetch_does_not_exist_should_throw(self):
+        non_existent_dir = os.path.join(self.test_dir, "non_existent_dir")
+        fetcher = LocalDirectoryImageFetcher()
+        with self.assertRaises(ValueError):
+            fetcher.fetch(non_existent_dir)
+
+
+class LocalSchedulerTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp("LocalSchedulerTest")
+        write_shell_script(self.test_dir, "touch.sh", ["touch $1"])
+        write_shell_script(self.test_dir, "fail.sh", ["exit 1"])
+        write_shell_script(self.test_dir, "sleep.sh", ["sleep $1"])
+
+        self.image_fetcher = LocalDirectoryImageFetcher()
+        self.scheduler = LocalScheduler(self.image_fetcher)
+
+        self.test_container = Container(image=self.test_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_submit(self):
+        test_file = os.path.join(self.test_dir, "test_file")
+        role = (
+            Role("role1")
+            .runs("touch.sh", test_file)
+            .on(self.test_container)
+            .replicas(2)
+        )
+        app = Application(name="test_app").of(role)
+
+        app_id = self.scheduler.submit(app, RunMode.HEADLESS)
+
+        self.assertEqual("test_app_0", app_id)
+        self.assertEqual(AppState.SUCCEEDED, self.scheduler.wait(app_id).state)
+        self.assertTrue(os.path.isfile(test_file))
+
+        role = Role("role1").runs("fail.sh").on(self.test_container).replicas(2)
+        app = Application(name="test_app").of(role)
+        app_id = self.scheduler.submit(app, RunMode.HEADLESS)
+
+        self.assertEqual("test_app_1", app_id)
+        self.assertEqual(AppState.FAILED, self.scheduler.wait(app_id).state)
+
+    def test_submit_multiple_roles(self):
+        test_file1 = os.path.join(self.test_dir, "test_file_1")
+        test_file2 = os.path.join(self.test_dir, "test_file_2")
+        role1 = (
+            Role("role1")
+            .runs("touch.sh", test_file1)
+            .on(self.test_container)
+            .replicas(1)
+        )
+        role2 = (
+            Role("role2")
+            .runs("touch.sh", test_file2)
+            .on(self.test_container)
+            .replicas(1)
+        )
+        app = Application(name="test_app").of(role1, role2)
+        app_id = self.scheduler.submit(app, RunMode.HEADLESS)
+
+        self.assertEqual(AppState.SUCCEEDED, self.scheduler.wait(app_id).state)
+        self.assertTrue(os.path.isfile(test_file1))
+        self.assertTrue(os.path.isfile(test_file2))
+
+    def test_describe(self):
+        role = Role("role1").runs("sleep.sh", "2").on(self.test_container).replicas(1)
+        app = Application(name="test_app").of(role)
+        self.assertIsNone(self.scheduler.describe("test_app_0"))
+        app_id = self.scheduler.submit(app, RunMode.HEADLESS)
+        desc = self.scheduler.describe(app_id)
+        self.assertEqual(AppState.RUNNING, desc.state)
+        self.assertEqual(AppState.SUCCEEDED, self.scheduler.wait(app_id).state)
+
+    def test_cancel(self):
+        role = Role("role1").runs("sleep.sh", "10").on(self.test_container).replicas(1)
+        app = Application(name="test_app").of(role)
+        app_id = self.scheduler.submit(app, RunMode.HEADLESS)
+        desc = self.scheduler.describe(app_id)
+        self.assertEqual(AppState.RUNNING, desc.state)
+        self.scheduler.cancel(app_id)
+        self.assertEqual(AppState.CANCELLED, self.scheduler.describe(app_id).state)
+
+    def test_exists(self):
+        role = Role("role1").runs("sleep.sh", "10").on(self.test_container).replicas(1)
+        app = Application(name="test_app").of(role)
+        app_id = self.scheduler.submit(app, RunMode.HEADLESS)
+
+        self.assertTrue(self.scheduler.exists(app_id))
+        self.scheduler.cancel(app_id)
+        self.assertTrue(self.scheduler.exists(app_id))
+
+    def test_wait_timeout(self):
+        role = Role("role1").runs("sleep.sh", "10").on(self.test_container).replicas(1)
+        app = Application(name="test_app").of(role)
+        app_id = self.scheduler.submit(app, RunMode.MANAGED)
+
+        with self.assertRaises(TimeoutError):
+            self.scheduler.wait(app_id, timeout=1)
+
+    def test_invalid_cache_size(self):
+        with self.assertRaises(ValueError):
+            LocalScheduler(self.image_fetcher, cache_size=0)
+
+        with self.assertRaises(ValueError):
+            LocalScheduler(self.image_fetcher, cache_size=-1)
+
+    def test_cache_full(self):
+        scheduler = LocalScheduler(self.image_fetcher, cache_size=1)
+
+        role = Role("role1").runs("sleep.sh", "10").on(self.test_container).replicas(1)
+        app = Application(name="test_app").of(role)
+        scheduler.submit(app, RunMode.MANAGED)
+        with self.assertRaises(IndexError):
+            scheduler.submit(app, RunMode.MANAGED)
+
+    def test_cache_evict(self):
+        scheduler = LocalScheduler(self.image_fetcher, cache_size=1)
+        test_file1 = os.path.join(self.test_dir, "test_file_1")
+        test_file2 = os.path.join(self.test_dir, "test_file_2")
+        role1 = Role("role1").runs("touch.sh", test_file1).on(self.test_container)
+        role2 = Role("role2").runs("touch.sh", test_file2).on(self.test_container)
+        app1 = Application(name="touch_test_file1").of(role1)
+        app2 = Application(name="touch_test_file2").of(role2)
+
+        app_id1 = scheduler.submit(app1, RunMode.HEADLESS)
+        self.assertEqual(AppState.SUCCEEDED, scheduler.wait(app_id1).state)
+
+        app_id2 = scheduler.submit(app2, RunMode.HEADLESS)
+        self.assertEqual(AppState.SUCCEEDED, scheduler.wait(app_id2).state)
+
+        # app1 should've been evicted
+        self.assertIsNone(scheduler.describe(app_id1))
+        self.assertIsNone(scheduler.wait(app_id1))
+
+        self.assertIsNotNone(scheduler.describe(app_id2))
+        self.assertIsNotNone(scheduler.wait(app_id2))

--- a/test/tsm/driver/standalone_session_test.py
+++ b/test/tsm/driver/standalone_session_test.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+import shutil
+import tempfile
+import unittest
+
+from torchelastic.tsm.driver.api import (
+    AppNotReRunnableException,
+    AppState,
+    Container,
+    Resources,
+    RunMode,
+    UnknownAppException,
+)
+from torchelastic.tsm.driver.local_scheduler import (
+    LocalDirectoryImageFetcher,
+    LocalScheduler,
+)
+from torchelastic.tsm.driver.standalone_session import StandaloneSession
+
+from .test_util import write_shell_script
+
+
+class Resource:
+    SMALL = Resources(cpu=1, gpu=0, memMB=1024)
+    MEDIUM = Resources(cpu=4, gpu=0, memMB=(4 * 1024))
+    LARGE = Resources(cpu=16, gpu=0, memMB=(16 * 1024))
+
+
+class StandaloneSessionTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp("StandaloneSessionTest")
+
+        write_shell_script(self.test_dir, "touch.sh", ["touch $1"])
+        write_shell_script(self.test_dir, "fail.sh", ["exit 1"])
+        write_shell_script(self.test_dir, "sleep.sh", ["sleep $1"])
+
+        self.image_fetcher = LocalDirectoryImageFetcher()
+        self.scheduler = LocalScheduler(self.image_fetcher)
+
+        # resource ignored for local scheduler; adding as an example
+        self.test_container = Container(image=self.test_dir).require(Resource.SMALL)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_run(self):
+        test_file = os.path.join(self.test_dir, "test_file")
+        session = StandaloneSession(
+            name="test_session", scheduler=self.scheduler, wait_interval=1
+        )
+        role = (
+            session.role(name="touch")
+            .runs("touch.sh", test_file)
+            .on(self.test_container)
+        )
+        app = session.app("name").of(role)
+
+        app_id = session.run(app)
+        self.assertEqual(AppState.SUCCEEDED, session.wait(app_id).state)
+
+    def test_attach(self):
+        session1 = StandaloneSession(name="test_session1", scheduler=self.scheduler)
+        role = (
+            session1.role(name="sleep").runs("sleep.sh", "60").on(self.test_container)
+        )
+        app = session1.app("sleeper").of(role)
+
+        app_id = session1.run(app)
+
+        session2 = StandaloneSession(name="test_session2", scheduler=self.scheduler)
+        session2.attach(app_id)
+
+        self.assertEqual(AppState.RUNNING, session2.status(app_id).state)
+        session2.stop(app_id)
+        self.assertEqual(AppState.CANCELLED, session2.status(app_id).state)
+
+    def test_attach_and_run(self):
+        session1 = StandaloneSession(name="test_session1", scheduler=self.scheduler)
+        test_file = os.path.join(self.test_dir, "test_file")
+        role = (
+            session1.role(name="touch")
+            .runs("touch.sh", test_file)
+            .on(self.test_container)
+        )
+        app = session1.app("touch_test_file").of(role)
+        app_id = session1.run(app)
+
+        session2 = StandaloneSession(name="test_session2", scheduler=self.scheduler)
+        attached_app = session2.attach(app_id)
+        with self.assertRaises(AppNotReRunnableException):
+            session2.run(attached_app)
+
+    def test_list(self):
+        session = StandaloneSession(
+            name="test_session", scheduler=self.scheduler, wait_interval=1
+        )
+        role = session.role(name="touch").runs("sleep.sh", "1").on(self.test_container)
+        app = session.app("sleeper").of(role)
+
+        num_apps = 4
+
+        for _ in range(num_apps):
+            # since this test validates the list() API,
+            # we do not wait for the apps to finish so run the apps
+            # in managed mode so that the local scheduler reaps the apps on exit
+            session.run(app, mode=RunMode.MANAGED)
+
+        apps = session.list()
+        self.assertEqual(num_apps, len(apps))
+
+    def test_evict_non_existent_app(self):
+        # tests that apps previously run with this session that are finished and eventually
+        # removed by the scheduler also get removed from the session after a status() API has been
+        # called on the app
+
+        scheduler = LocalScheduler(self.image_fetcher, cache_size=1)
+        session = StandaloneSession(
+            name="test_session", scheduler=scheduler, wait_interval=1
+        )
+        test_file = os.path.join(self.test_dir, "test_file")
+        role = (
+            session.role(name="touch")
+            .runs("touch.sh", test_file)
+            .on(self.test_container)
+        )
+        app = session.app("touch_test_file").of(role)
+
+        # local scheduler was setup with a cache size of 1
+        # run the same app twice (the first will be removed from the scheduler's cache)
+        # then validate that the first one will drop from the session's app cache as well
+        app_id1 = session.run(app)
+        session.wait(app_id1)
+
+        app_id2 = session.run(app)
+        session.wait(app_id2)
+
+        apps = session.list()
+
+        self.assertEqual(1, len(apps))
+        self.assertFalse(app_id1 in apps)
+        self.assertTrue(app_id2 in apps)
+
+    def test_status(self):
+        session = StandaloneSession(
+            name="test_session", scheduler=self.scheduler, wait_interval=1
+        )
+        role = session.role(name="sleep").runs("sleep.sh", "60").on(self.test_container)
+        app = session.app("sleeper").of(role)
+        app_id = session.run(app)
+        self.assertEqual(AppState.RUNNING, session.status(app_id).state)
+        session.stop(app_id)
+        self.assertEqual(AppState.CANCELLED, session.status(app_id).state)
+
+    def test_status_unknown_app(self):
+        session = StandaloneSession(
+            name="test_session", scheduler=self.scheduler, wait_interval=1
+        )
+        with self.assertRaises(UnknownAppException):
+            session.status("unknown_app_id")
+
+    def test_wait_unknown_app(self):
+        session = StandaloneSession(
+            name="test_session", scheduler=self.scheduler, wait_interval=1
+        )
+        with self.assertRaises(UnknownAppException):
+            session.wait("unknown_app_id")
+
+    def test_stop_unknown_app(self):
+        session = StandaloneSession(
+            name="test_session", scheduler=self.scheduler, wait_interval=1
+        )
+        with self.assertRaises(UnknownAppException):
+            session.stop("unknown_app_id")

--- a/test/tsm/driver/test_util.py
+++ b/test/tsm/driver/test_util.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from typing import List
+
+
+def write_shell_script(dir: str, name: str, content: List[str]) -> str:
+    """
+    Creates and writes a bash script in the specified dir with the given name.
+    The contents of the script are taken from the ``content`` parameter
+    where each item in the list is written as a line in the script.
+
+    Example: ``write_shell_script("/tmp", "foobar", ["sleep 10", "echo hello world"])
+
+    ::
+
+    # creates /tmp/foobar with content below
+    #! bin/bash
+
+    sleep 10
+    echo hello world
+
+    """
+
+    script_path = os.path.join(dir, name)
+    with open(script_path, "w") as f:
+        f.write("#! /bin/bash\n")
+        for line in content:
+            f.write(f"{line}\n")
+        f.write("\n")
+
+    os.chmod(script_path, 0o755)
+    return script_path

--- a/torchelastic/tsm/__init__.py
+++ b/torchelastic/tsm/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchelastic/tsm/driver/__init__.py
+++ b/torchelastic/tsm/driver/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchelastic/tsm/driver/api.py
+++ b/torchelastic/tsm/driver/api.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import abc
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class BaseObject:
+    """
+    Base object class that all object APIs inherit from. Standardizes
+    things like serialization, versioning, to_string methods.
+
+    # TODO add serde + versioning methods for robust session.attach(app_id)
+    """
+
+    def __repr__(self):
+        str = []
+        for (field, value) in self.__dict__.items():
+            str.append(f"{field}:{value.__repr__()}")
+        return f"{{{', '.join(str)}}}"
+
+
+class Resources(BaseObject):
+    """
+    Represents resource requirements for a ``Container``.
+    """
+
+    __slots__ = ("cpu", "gpu", "memMB", "capabilities")
+
+    def __init__(
+        self,
+        cpu: int,
+        gpu: int,
+        memMB: int,
+        capabilities: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Arguments:
+            cpu: number of cpus
+            gpu: number of gpus
+            memMB: MB of ram
+            metadata: additional hardware specs (interpreted by scheduler)
+        """
+        self.cpu: int = cpu
+        self.gpu: int = gpu
+        self.memMB: int = memMB
+        self.capabilities: Optional[Dict[str, Any]] = capabilities
+
+
+# used for cases when resource does not matter (e.g. ignored)
+NULL_RESOURCE: Resources = Resources(cpu=-1, gpu=-1, memMB=-1)
+
+
+class Container(BaseObject):
+    """
+    Represents the specifications of the container that instances of ``Roles``
+    run on. Maps to the container abstraction that the underlying scheduler
+    supports. This could be an actual container (e.g. Docker) or a physical
+    instance depending on the scheduler.
+
+    An ``image`` is a software bundle that is installed on a ``Container``.
+    The container on the scheduler dictates what an image actually is.
+    An image could be as simple as a tar-ball or map to a docker image.
+    The scheduler typically knows how to "pull" the image given an
+    image name (str), which could be a simple name (e.g. docker image) or a url
+    (e.g. s3://path/my_image.tar).
+
+    Usage:
+
+    ::
+
+    my_container = Container(image="pytorch/torch:1")
+                       .require(Resources(cpu=1, gpu=1, memMB=500))
+                       .ports(tcp_store=8080, tensorboard=8081)
+    """
+
+    def __init__(self, image: str):
+        self.image: str = image
+        self.resources: Resources = NULL_RESOURCE
+        self.port_map: Dict[str, int] = {}
+
+    def require(self, resources: Resources) -> "Container":
+        """
+        Sets resource requirements on the container.
+        """
+        self.resources = resources
+        return self
+
+    def ports(self, **kwargs: int) -> "Container":
+        """
+        Adds a port mapping for the container
+        """
+        self.port_map.update({**kwargs})
+        return self
+
+
+# used as the "zero" element in the container group
+NULL_CONTAINER: Container = Container(image="<NULL_IMAGE>")
+
+
+class Role(BaseObject):
+    """
+    A set of nodes that perform a specific duty within the ``Application``.
+    Examples:
+
+    1. Distributed data parallel app - made up of a single role (trainer).
+
+    2. App with parameter server - made up of multiple roles (trainer, ps).
+
+    Usage:
+
+    ::
+
+    trainer = Role(name="trainer")
+                 .runs("my_trainer.py", "--arg", "foo", ENV_VAR="FOOBAR")
+                 .on(container)
+                 .replicas(4)
+    """
+
+    def __init__(self, name: str):
+        """
+        Arguments:
+            name - name of the role
+            entrypoint - command (within the container) to invoke the role
+            args - commandline arguments to the entrypoint cmd
+            env - environment variable mappings
+            container - container to run in
+            replicas - number of container replicas to run
+        """
+        self.name: str = name
+        self.entrypoint: str = ""
+        self.args: List[str] = []
+        self.env: Dict[str, str] = {}
+        self.container: Container = NULL_CONTAINER
+        self.num_replicas: int = 1
+
+    def runs(self, entrypoint: str, *args: str, **kwargs: str) -> "Role":
+        self.entrypoint = entrypoint
+        self.args += [*args]
+        self.env.update({**kwargs})
+        return self
+
+    def on(self, container: Container) -> "Role":
+        self.container = container
+        return self
+
+    def replicas(self, replicas: int) -> "Role":
+        self.num_replicas = replicas
+        return self
+
+
+class RunMode(Enum):
+    """
+    Run mode of the application. Supported modes are:
+
+    1. HEADLESS - Application is allowed to continue running even when the
+                  hosting session has terminated. This is the default mode.
+
+    2. MANAGED - Application's lifetime is bound to the hosting session. If
+                 the session goes away, so will the app.
+    """
+
+    HEADLESS = 0
+    MANAGED = 1
+
+
+class Application(BaseObject):
+    """
+    Represents a distributed application made up of multiple ``Roles``.
+    Contains the necessary information for the driver to submit this
+    app to the scheduler.
+    """
+
+    def __init__(self, name: str, run_mode: RunMode = RunMode.HEADLESS):
+        self.name = name
+        self.roles: List[Role] = []
+        self.run_mode = run_mode
+        self.is_attached: bool = False
+
+    def of(self, *roles: Role) -> "Application":
+        self.roles += [*roles]
+        return self
+
+
+class AppState(Enum):
+    """
+    State of the application. An application starts from an initial
+    ``UNSUBMITTED`` state and moves through ``SUBMITTED``, ``PENDING``,
+    ``RUNNING`` states finally reaching a terminal state:
+    ``SUCCEEDED``,``FAILED``, ``CANCELLED``.
+
+    If the scheduler supports preemption, the app moves from a ``RUNNING``
+    state to ``PENDING`` upon preemption.
+
+    If the user stops the application, then the application state moves
+    to ``STOPPED``, then to ``CANCELLED`` when the job is actually cancelled
+    by the scheduler.
+
+    1. UNSUBMITTED - app has not been submitted to the scheduler yet
+    2. SUBMITTED - app has been successfully submitted to the scheduler
+    3. PENDING - app has been submitted to the scheduler pending allocation
+    4. RUNNING - app is running
+    5. SUCCEEDED - app has successfully completed
+    6. FAILED - app has unsuccessfully completed
+    7. CANCELLED - app was cancelled before completing
+    """
+
+    UNSUBMITTED = 0
+    SUBMITTED = 1
+    PENDING = 2
+    RUNNING = 3
+    SUCCEEDED = 4
+    FAILED = 5
+    CANCELLED = 6
+
+
+_TERMINAL_STATES = [AppState.SUCCEEDED, AppState.FAILED, AppState.CANCELLED]
+
+
+def is_terminal(state: AppState) -> bool:
+    return state in _TERMINAL_STATES
+
+
+class AppStatus:
+    """
+    The runtime status of the ``Application``.
+    """
+
+    def __init__(self, state: AppState, num_restarts: int = 0, msg: str = ""):
+        self.state: AppState = state
+        self.num_restarts: int = num_restarts
+        self.msg: str = msg
+
+    def is_terminal(self) -> bool:
+        return is_terminal(self.state)
+
+
+class DescribeAppResponse:
+    """
+    Response object returned by ``Scheduler.describe(app)`` API. Contains
+    the status and description of the application as known by the scheduler.
+    For some schedulers implementations this response object has necessary
+    and sufficient information to recreate an ``Application`` object in the
+    absence of the hosting ``Session``. For these types of schedulers,
+    the user can re-``run()`` the attached application. Otherwise the user
+    can only call non-creating methods (e.g. ``wait()``, ``status()``, etc).
+
+    Since this class is a data class and contains many member variables we
+    keep the usage simple and provide a no-args constructor and chose to
+    access the member vars directly rather than provide accessors.
+    """
+
+    def __init__(self):
+        self.app_id: str = "<NOT_SET>"
+        self.state: AppState = AppState.UNSUBMITTED
+        self.num_restarts: int = -1
+        # TODO add other fields that come back from the scheduler's describe
+        # API. Typically this includes some type of JobDefinition which
+        # contains all the data to recreate the Application object. Store them
+        # here as member vars so that we can implement the session.attach() api:
+        #
+        # app_id = session.run(app_orig)
+        # /* session is lost, create a new session */
+        # new_session = Session(...)
+        # /* upon attaching the app, app is recreated */
+        # app_new = session.attach(app_id)
+        # assert app_new == app_orig
+
+
+class Scheduler(abc.ABC):
+    """
+    An interface abstracting functionalities of a scheduler.
+    Implementors need only implement those methods annotated with
+    ``@abc.abstractmethod``.
+    """
+
+    @abc.abstractmethod
+    def submit(self, app: Application, mode: RunMode) -> str:
+        """
+        Submits the application to be run by the scheduler.
+
+        Returns:
+            The application id that uniquely identifies the submitted app.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def describe(self, app_id: str) -> Optional[DescribeAppResponse]:
+        """
+        Describes the specified application.
+
+        Returns:
+            Application description or ``None`` if the app does not exist.
+        """
+        raise NotImplementedError()
+
+    def exists(self, app_id: str):
+        """
+        Returns:
+            ``True`` if the app exists (was submitted), ``False`` otherwise
+        """
+        desc = self.describe(app_id)
+        return desc is not None
+
+    @abc.abstractmethod
+    def _cancel_existing(self, app_id: str) -> None:
+        """
+        Kills the application. This method will only be called on an
+        application that exists.
+        """
+        raise NotImplementedError()
+
+    def cancel(self, app_id: str) -> None:
+        """
+        Cancels/kills the application. This method is idempotent within the same
+        thread and is safe to call on the same application multiple times.
+        However when called from multiple threads/processes on the same app
+        the exact semantics of this method depends on the idempotency guarantees
+        of the underlying scheduler API.
+
+        .. note:: This method does not block for the application to reach a
+                  cancelled state. To ensure that the application reaches a
+                  terminal state use the ``wait`` API.
+        """
+        if self.exists(app_id):
+            self._cancel_existing(app_id)
+        else:
+            # do nothing if the app does not exist
+            return
+
+
+class UnknownAppException(Exception):
+    """
+    Raised by ``Session`` APIs when either the application does not
+    exist or the application is not owned by the session.
+    """
+
+    def __init__(self, app_id: str):
+        super().__init__(
+            f"Unknown app = {app_id}. Did you forget to call session.run() or session.attach()?"
+        )
+
+
+class AppNotReRunnableException(Exception):
+    """
+    Raised when the application is not re-runnable. That is, one cannot have two run instances
+    of the same application. See ``Session.attach()`` for when this is the case.
+    """
+
+    def __init__(self, app: Application):
+        super().__init__(
+            f"App {app.name} is not re-runnable. To re-run attached apps, use a session/scheduler that supports such action."
+        )
+
+
+class Session(abc.ABC):
+    """
+    Entrypoint and client-facing API for TSM. Has the methods for the user to
+    define and act upon ``Applications``. The ``Session`` is stateful and
+    represents a logical workspace of the user. It can be backed by a service
+    (e.g. TSM server) for persistence or can be standalone with no persistence
+    meaning that the ``Session`` lasts only during the duration of the hosting
+    process (see the ``attach()`` API for instructions on re-parenting apps
+    between sessions).
+    """
+
+    def __init__(self, name: str):
+        self._name: str = name
+
+        # object APIs
+        self.app = Application
+        self.role = Role
+        self.container = Container
+
+    def name(self) -> str:
+        """
+        Returns:
+            The name of this session.
+        """
+        return self._name
+
+    def run(self, app: Application, mode: RunMode = RunMode.HEADLESS) -> str:
+        # input validation
+        if not app.roles:
+            raise ValueError(
+                f"No roles for app: {app.name}. Did you forget to call app.of(roles..)?"
+            )
+
+        for role in app.roles:
+            if not role.entrypoint:
+                raise ValueError(
+                    f"No entrypoint for role: {role.name}. Did you forget to call role.runs(entrypoint, args, env)?"
+                )
+            if role.num_replicas <= 0:
+                raise ValueError(
+                    f"Non-positive replicas for role: {role.name}. Did you forget to call role.replicas(positive_number)?"
+                )
+            if role.container == NULL_CONTAINER:
+                raise ValueError(
+                    f"No container for role: {role.name}. Did you forget to call role.on(container)"
+                )
+            if role.container.resources == NULL_RESOURCE:
+                raise ValueError(
+                    f"No resources for container: {role.container.image}. Did you forget to call container.require(resources)"
+                )
+
+        return self._run(app, mode)
+
+    @abc.abstractmethod
+    def _run(self, app: Application, mode: RunMode = RunMode.HEADLESS) -> str:
+        """
+        Runs the given application in the specified mode.
+
+        Returns:
+            The application id that is used to call other action APIs on the app
+
+        Raises:
+            AppNotReRunnableException - if the session/scheduler does not support re-running attached apps
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def status(self, app_id: str) -> Optional[AppStatus]:
+        """
+        Returns:
+            The status of the application, or ``None`` if the app does not exist anymore
+            (e.g. was stopped in the past and removed from the scheduler's backend).
+
+        Raises:
+            UnknownAppException - if the app was never run or attached on this session
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def wait(self, app_id: str) -> Optional[AppStatus]:
+        """
+        Block waits (indefinitely) for the application to complete.
+        Possible implementation:
+
+        ::
+
+        while(True):
+            app_status = status(app)
+            if app_status.is_terminal():
+                return
+            sleep(10)
+
+        Returns:
+            The terminal status of the application, or ``None`` if the app does not exist anymore
+
+        Raises:
+            UnknownAppException - if the app was never run or attached on this session
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def list(self) -> Dict[str, Application]:
+        """
+        Returns the applications that were run with this session mapped by the app_id.
+        The persistence of the session is implementation dependent.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def stop(self, app_id: str) -> None:
+        """
+        Stops the application, effectively directing the scheduler to cancel
+        the job.
+
+        .. note:: This method returns as soon as the cancel request has been
+                  submitted to the scheduler. The application will be in a
+                  ``RUNNING`` state until the scheduler actually terminates
+                  the job. If the scheduler successfully interrupts the job
+                  and terminates it the final state will be ``CANCELLED``
+                  otherwise it will be ``FAILED``.
+
+        Raises:
+            UnknownAppException - if app was never run or attached on this session
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def attach(self, app_id: str) -> Application:
+        """
+        Attaches the application represented by the provided ``app_id``.
+        If the app is already attached to this session, then does nothing
+        and returns the existing ``Application`` object.
+
+        Whether all action APIs are supported on the attached application
+        is dependent on the specific implementation of the session and scheduler.
+        For instance a ``StandaloneSession`` with no persistent backend cannot
+        fully recreate the application without the underlying scheduler
+        supporting a ``job_definition`` API that stores the job's template.
+        Hence in this case, the user will not be able to re-run the attached
+        app and can only call action APIs that require only the ``app_id``
+        to execute. Please refer to the specific session and scheduler
+        implementation documentations to understand the attach behavior,
+        assumptions, and consequences.
+
+        Returns:
+            The re-created application object
+
+        Raises:
+            UnknownAppException - if app was never run or attached on this session
+        """
+        raise NotImplementedError()

--- a/torchelastic/tsm/driver/local_scheduler.py
+++ b/torchelastic/tsm/driver/local_scheduler.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import abc
+import os
+import subprocess
+import sys
+import time
+from typing import Dict, List, Optional
+
+from torchelastic.tsm.driver.api import (
+    Application,
+    AppState,
+    DescribeAppResponse,
+    RunMode,
+    Scheduler,
+    is_terminal,
+)
+from torchelastic.utils.logging import get_logger
+
+
+log = get_logger()
+
+
+class ImageFetcher(abc.ABC):
+    """
+    Downloads and sets up an image onto the localhost. This is only needed for
+    ``LocalhostScheduler`` since typically real schedulers will do this
+    on-behalf of the user.
+    """
+
+    @abc.abstractmethod
+    def fetch(self, image: str) -> str:
+        """
+        Pulls the given image and returns a path to the pulled image on
+        the local host.
+        """
+        raise NotImplementedError()
+
+
+class LocalDirectoryImageFetcher(ImageFetcher):
+    """
+    Interprets the image name as the path to a directory on
+    local host. Does not "fetch" (e.g. download) anything. Used in conjunction
+    with ``LocalScheduler`` to run local binaries.
+
+    The image name must be an absolute path and must exist.
+
+    Example:
+
+    1. ``fetch(Image(name="/tmp/foobar"))`` returns ``/tmp/foobar``
+    2. ``fetch(Image(name="foobar"))`` raises ``ValueError``
+    2. ``fetch(Image(name="/tmp/dir/that/does/not_exist"))`` raises ``ValueError``
+    """
+
+    def fetch(self, image: str) -> str:
+        """
+        Raises:
+            ValueError - if the image name is not an absolute dir
+                         and if it does not exist or is not a directory
+
+        """
+        if not os.path.isabs(image):
+            raise ValueError(
+                f"Invalid image name: {image}, image name must be an absolute path"
+            )
+
+        if not os.path.isdir(image):
+            raise ValueError(
+                f"Invalid image name: {image}, does not exist or is not a directory"
+            )
+
+        return image
+
+
+# aliases to make clear what the mappings are
+AppId = str
+AppName = str
+RoleName = str
+
+
+class _LocalApplication:
+    """
+    Container object used by ``LocalhostScheduler`` to group the pids that
+    form an application. Each replica of a role in the application is a
+    process and has a pid.
+    """
+
+    def __init__(self, name: str):
+        self.name = name
+        # role name -> proc_1, proc_2, ... (proc for each replica)
+        self.role_procs: Dict[RoleName, List[subprocess.Popen]] = {}
+        self.state: AppState = AppState.PENDING
+        # time (in seconds since epoch) when the last set_state method() was called
+        self.last_updated: float = -1
+        self.run_mode: RunMode = RunMode.MANAGED
+
+    def add_process(self, role_name: str, proc: subprocess.Popen) -> None:
+        procs = self.role_procs.setdefault(role_name, [])
+        procs.append(proc)
+
+    def set_state(self, state: AppState):
+        self.last_updated = time.time()
+        self.state = state
+
+    def set_run_mode(self, mode: RunMode):
+        self.run_mode = mode
+
+    def __repr__(self):
+        role_to_pid = {}
+        for (role_name, procs) in self.role_procs.items():
+            pids = role_to_pid.setdefault(role_name, [])
+            for p in procs:
+                pids.append(p.pid)
+
+        return f"{{name:{self.name}, state:{self.state}, mode:{self.run_mode}, pid_map:{role_to_pid}}}"
+
+
+class LocalScheduler(Scheduler):
+    """
+    Schedules on localhost. Containers are modeled as processes and
+    certain properties of the container that are either not relevant
+    or that cannot be enforced for localhost
+    runs are ignored. Properties that are ignored:
+
+    1. Resource requirements
+    2. Container limit enforcements
+    3. Restart policies
+    4. Retry counts (no retries supported)
+
+    ..note:: Use this scheduler sparingly since an application
+             that runs successfully on a session backed by this
+             scheduler may not work on an actual production cluster
+             using a different scheduler.
+    """
+
+    def __init__(self, image_fetcher: ImageFetcher, cache_size: int = 100):
+        # for each app name keeps an incrementing id, to support running
+        # multiple instances of the same app
+        self._ids: Dict[AppName, int] = {}
+        # TODO for long running local scheduler make this an LRU cache
+        # and don't forget to remove the app name from "_ids" when evicting finished apps=
+        self._apps: Dict[AppId, _LocalApplication] = {}
+        self._image_fetcher = image_fetcher
+
+        if cache_size <= 0:
+            raise ValueError("cache size must be greater than zero")
+        self._cache_size = cache_size
+
+    def _evict_lru(self) -> bool:
+        """
+        Evicts one least recently used element from the apps cache. LRU is defined as
+        the oldest app in a terminal state (e.g. oldest finished app).
+
+        Returns:
+            ``True`` if an entry was evicted, ``False`` if no entries could be evicted
+            (e.g. all apps are running)
+        """
+        lru_time = sys.maxsize
+        lru_app_id = None
+        for (app_id, app) in self._apps.items():
+            if is_terminal(app.state):
+                if app.last_updated <= lru_time:
+                    lru_app_id = app_id
+
+        if lru_app_id:
+            # evict LRU finished app from the apps cache
+            # do not remove the app name from the ids map so that the ids
+            # remain unique throughout the lifespan of this scheduler
+            # for example if cache size == 1
+            #     app_id1 = submit(app)
+            #     app_id2 = submit(app) # app_id1 was evicted here
+            #     app_id1 == "app.name_0"
+            #     app_id2 == "app.name_1"
+            del self._apps[lru_app_id]
+
+            log.debug(f"evicting app: {lru_app_id}, from local scheduler cache")
+            return True
+        else:
+            log.debug(f"no apps evicted, all {len(self._apps)} apps are running")
+            return False
+
+    def submit(self, app: Application, mode: RunMode) -> str:
+        if len(self._apps) == self._cache_size:
+            if not self._evict_lru():
+                raise IndexError(
+                    f"App cache size ({self._cache_size}) exceeded. Increase the cache size"
+                )
+
+        id = self._ids.setdefault(app.name, -1) + 1
+        self._ids[app.name] = id
+        app_id = f"{app.name}_{id}"
+
+        assert (
+            app_id not in self._apps
+        ), "no app_id collisons expected since incremental integer suffix is used"
+
+        local_app = _LocalApplication(app.name)
+        local_app.set_run_mode(mode)
+
+        for role in app.roles:
+            container = role.container
+            assert (
+                container
+            ), "all roles in a submitted app must have container association"
+
+            img_root = self._image_fetcher.fetch(container.image)
+            cmd = os.path.join(img_root, role.entrypoint)
+            for _ in range(role.num_replicas):
+                args = [cmd] + role.args
+                proc = subprocess.Popen(args, env=role.env)
+                local_app.add_process(role.name, proc)
+
+        self._apps[app_id] = local_app
+        return app_id
+
+    def _failed(self, p: subprocess.Popen):
+        if self._is_alive(p):
+            return False
+        else:
+            return p.returncode != 0
+
+    def describe(self, app_id: str) -> Optional[DescribeAppResponse]:
+        if app_id not in self._apps:
+            return None
+
+        local_app = self._apps[app_id]
+
+        # check if the app has been known to have finished
+        if is_terminal(local_app.state):
+            state = local_app.state
+        else:
+            running = False
+            failed = False
+            for (_, procs) in local_app.role_procs.items():
+                for p in procs:
+                    running |= self._is_alive(p)
+                    failed |= self._failed(p)
+
+            if running:
+                state = AppState.RUNNING
+            elif failed:
+                state = AppState.FAILED
+                self._terminate(local_app)  # terminate danglers
+            else:
+                state = AppState.SUCCEEDED
+            local_app.set_state(state)
+
+        resp = DescribeAppResponse()
+        resp.app_id = app_id
+        resp.state = state
+        resp.num_restarts = 0
+        return resp
+
+    def _is_alive(self, p: subprocess.Popen):
+        return p.poll() is None
+
+    def _terminate(self, app: _LocalApplication):
+        for (_, procs) in app.role_procs.items():
+            for p in procs:
+                # safe to call terminate on a process that already died
+                p.terminate()
+                p.wait()
+
+    def _cancel_existing(self, app_id: str) -> None:
+        # can assume app_id exists
+        local_app = self._apps[app_id]
+        self._terminate(local_app)
+        local_app.state = AppState.CANCELLED
+
+    def wait(self, app_id: str, timeout=-1) -> Optional[DescribeAppResponse]:
+        """
+        Waits for the app to finish or raise TimeoutError upon timeout (in seconds).
+        If no timeout is specified waits indefinitely.
+
+        Returns:
+            The last return value from ``describe()``
+        """
+
+        if timeout > 0:
+            expiry = time.time()
+            interval = timeout / 10
+        else:
+            expiry = sys.maxsize
+            interval = 1
+
+        while expiry > time.time():
+            desc = self.describe(app_id)
+
+            if desc is None:
+                return None
+            elif is_terminal(desc.state):
+                return desc
+
+            time.sleep(interval)
+
+        raise TimeoutError(f"timed out waiting for app: {app_id} to finish")
+
+    def __del__(self):
+        # terminate all MANAGED apps
+        for (app_id, app) in self._apps.items():
+            if app.run_mode == RunMode.MANAGED:
+                log.info(f"Terminating managed app: {app_id}")
+                self._cancel_existing(app_id)

--- a/torchelastic/tsm/driver/standalone_session.py
+++ b/torchelastic/tsm/driver/standalone_session.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+from typing import Dict, Optional
+
+from torchelastic.tsm.driver.api import (
+    Application,
+    AppNotReRunnableException,
+    AppStatus,
+    RunMode,
+    Scheduler,
+    Session,
+    UnknownAppException,
+)
+
+
+class StandaloneSession(Session):
+    def __init__(self, name: str, scheduler: Scheduler, wait_interval: int = 10):
+        super().__init__(name)
+        self._scheduler = scheduler
+        self._wait_interval = wait_interval
+
+        # TODO implement an LRU cache (see local_scheduler.py) and use it here and also in local_scheduler
+        # app_id -> Application
+        self._apps: Dict[str, Application] = {}
+
+    def run(self, app: Application, mode: RunMode = RunMode.HEADLESS) -> str:
+        if app.is_attached:
+            raise AppNotReRunnableException(app)
+        return super().run(app, mode)
+
+    def _run(self, app: Application, mode: RunMode = RunMode.HEADLESS) -> str:
+        app_id = self._scheduler.submit(app, mode)
+        self._apps[app_id] = app
+        return app_id
+
+    def status(self, app_id: str) -> Optional[AppStatus]:
+        if app_id not in self._apps:
+            raise UnknownAppException(app_id)
+
+        desc = self._scheduler.describe(app_id)
+        if not desc:
+            # app does not exist on the scheduler; remove it from apps cache
+            # effectively removes this app from the list() API
+            del self._apps[app_id]
+            return None
+
+        msg = "TODO return a message"
+        return AppStatus(desc.state, desc.num_restarts, msg)
+
+    def wait(self, app_id: str) -> Optional[AppStatus]:
+        while True:
+            app_status = self.status(app_id)
+
+            if not app_status:
+                return None
+            if app_status.is_terminal():
+                return app_status
+            else:
+                time.sleep(self._wait_interval)
+
+    def list(self) -> Dict[str, Application]:
+        # opportunistically query for each app's status to update the app
+        # copy the keys (app ids) since status(app_id) mutates self._apps
+        app_ids = list(self._apps.keys())
+        for app_id in app_ids:
+            self.status(app_id)
+        return self._apps
+
+    def stop(self, app_id: str) -> None:
+        status = self.status(app_id)
+        if status is None or status.is_terminal():
+            return  # do nothing; app does not exist or has already finished
+        else:
+            self._scheduler.cancel(app_id)
+
+    def attach(self, app_id: str) -> Application:
+        # TODO recreate the app to the best extent; empty app for now (e.g. cannot re-run the app)
+        app = Application(name=app_id)
+        app.is_attached = True
+        self._apps[app_id] = app
+        return app


### PR DESCRIPTION
Summary:
Initial API skeleton for TSM standalone driver.

See: https://fb.quip.com/aDgrAvxbc7sK

NOTE: See `standalone_session_test#run()` for an E2E example (see screenshot below)
{F290163742}

NOTE: thanks yifuwang and tierex for the prompt review on a partially done diff. I'll address the comments tomorrow before submitting a V4 draft ready to land.

Reviewed By: tierex, yifuwang

Differential Revision: D23121966

