### PR TITLE
implement ElasticRole, role args macro substitution

### DIFF
--- a/torchelastic/tsm/driver/__init__.py
+++ b/torchelastic/tsm/driver/__init__.py
@@ -14,11 +14,16 @@ from torchelastic.tsm.driver.api import (  # noqa: F401 F403
     Role,
     RunMode,
     Session,
+    macros,
 )
 from torchelastic.tsm.driver.schedulers import get_scheduler
-from torchelastic.tsm.driver.standalone_session import (  # noqa: F401 F403
-    StandaloneSession,
-)
+from torchelastic.tsm.driver.standalone_session import StandaloneSession
+
+
+try:
+    from torchelastic.tsm.driver.api_extended import *  # noqa: F401 F403
+except ModuleNotFoundError:
+    pass
 
 
 def session(

--- a/torchelastic/tsm/driver/test/standalone_session_test.py
+++ b/torchelastic/tsm/driver/test/standalone_session_test.py
@@ -11,10 +11,12 @@ import tempfile
 import unittest
 
 from torchelastic.tsm.driver.api import (
+    Application,
     AppNotReRunnableException,
     AppState,
     Container,
     Resources,
+    Role,
     RunMode,
     UnknownAppException,
 )
@@ -55,22 +57,16 @@ class StandaloneSessionTest(unittest.TestCase):
         session = StandaloneSession(
             name="test_session", scheduler=self.scheduler, wait_interval=1
         )
-        role = (
-            session.role(name="touch")
-            .runs("touch.sh", test_file)
-            .on(self.test_container)
-        )
-        app = session.app("name").of(role)
+        role = Role(name="touch").runs("touch.sh", test_file).on(self.test_container)
+        app = Application("name").of(role)
 
         app_id = session.run(app)
         self.assertEqual(AppState.SUCCEEDED, session.wait(app_id).state)
 
     def test_attach(self):
         session1 = StandaloneSession(name="test_session1", scheduler=self.scheduler)
-        role = (
-            session1.role(name="sleep").runs("sleep.sh", "60").on(self.test_container)
-        )
-        app = session1.app("sleeper").of(role)
+        role = Role(name="sleep").runs("sleep.sh", "60").on(self.test_container)
+        app = Application("sleeper").of(role)
 
         app_id = session1.run(app)
 
@@ -84,12 +80,8 @@ class StandaloneSessionTest(unittest.TestCase):
     def test_attach_and_run(self):
         session1 = StandaloneSession(name="test_session1", scheduler=self.scheduler)
         test_file = os.path.join(self.test_dir, "test_file")
-        role = (
-            session1.role(name="touch")
-            .runs("touch.sh", test_file)
-            .on(self.test_container)
-        )
-        app = session1.app("touch_test_file").of(role)
+        role = Role(name="touch").runs("touch.sh", test_file).on(self.test_container)
+        app = Application("touch_test_file").of(role)
         app_id = session1.run(app)
 
         session2 = StandaloneSession(name="test_session2", scheduler=self.scheduler)
@@ -101,8 +93,8 @@ class StandaloneSessionTest(unittest.TestCase):
         session = StandaloneSession(
             name="test_session", scheduler=self.scheduler, wait_interval=1
         )
-        role = session.role(name="touch").runs("sleep.sh", "1").on(self.test_container)
-        app = session.app("sleeper").of(role)
+        role = Role(name="touch").runs("sleep.sh", "1").on(self.test_container)
+        app = Application("sleeper").of(role)
 
         num_apps = 4
 
@@ -125,12 +117,8 @@ class StandaloneSessionTest(unittest.TestCase):
             name="test_session", scheduler=scheduler, wait_interval=1
         )
         test_file = os.path.join(self.test_dir, "test_file")
-        role = (
-            session.role(name="touch")
-            .runs("touch.sh", test_file)
-            .on(self.test_container)
-        )
-        app = session.app("touch_test_file").of(role)
+        role = Role(name="touch").runs("touch.sh", test_file).on(self.test_container)
+        app = Application("touch_test_file").of(role)
 
         # local scheduler was setup with a cache size of 1
         # run the same app twice (the first will be removed from the scheduler's cache)
@@ -151,8 +139,8 @@ class StandaloneSessionTest(unittest.TestCase):
         session = StandaloneSession(
             name="test_session", scheduler=self.scheduler, wait_interval=1
         )
-        role = session.role(name="sleep").runs("sleep.sh", "60").on(self.test_container)
-        app = session.app("sleeper").of(role)
+        role = Role(name="sleep").runs("sleep.sh", "60").on(self.test_container)
+        app = Application("sleeper").of(role)
         app_id = session.run(app)
         self.assertEqual(AppState.RUNNING, session.status(app_id).state)
         session.stop(app_id)


### PR DESCRIPTION
Summary:
This diff adds native support for a role that launches with `torchelastic` (a.k.a `ElasticRole`) to make this work I do the following three things:

1. Implements `ElasticRole` (and `ElasticRoleFB` for fb internal)
2. Implements macro substitution for `{img_root}` and `{app_id}` which can be used with `Role.args` (this is needed to specify `launch --elastic_args ${img_root}/my_trainer_binary.par`).
3. Removes redundant object APIs from `Session` and use them directly as defined in `torchelastic.tsm.driver.api`

Differential Revision: D23701234

