### PR TITLE
add replica_id macro

### DIFF
--- a/torchelastic/tsm/driver/local_scheduler.py
+++ b/torchelastic/tsm/driver/local_scheduler.py
@@ -213,8 +213,10 @@ class LocalScheduler(Scheduler):
 
             img_root = self._image_fetcher.fetch(container.image)
             cmd = os.path.join(img_root, role.entrypoint)
-            for _ in range(role.num_replicas):
-                args = [cmd] + macros.substitute(role.args, img_root, app_id)
+            for replica_id in range(role.num_replicas):
+                args = [cmd] + macros.substitute(
+                    role.args, img_root, app_id, str(replica_id)
+                )
                 log.info(f"Running {args} with env: {role.env}")
                 proc = subprocess.Popen(args, env=role.env)
                 local_app.add_process(role.name, proc)

--- a/torchelastic/tsm/driver/test/api_test.py
+++ b/torchelastic/tsm/driver/test/api_test.py
@@ -5,6 +5,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+import os
 import unittest
 from typing import Dict, Optional
 
@@ -102,6 +103,8 @@ class ElasticRoleBuilderTest(unittest.TestCase):
                 "etcd",
                 "--rdzv_id",
                 macros.app_id,
+                "--role",
+                "elastic_trainer",
                 "/bin/echo",
                 "hello",
                 "world",
@@ -126,7 +129,9 @@ class ElasticRoleBuilderTest(unittest.TestCase):
                 "zeus",
                 "--rdzv_id",
                 "foobar",
-                "user_script.py",
+                "--role",
+                "test_role",
+                os.path.join(macros.img_root, "user_script.py"),
                 "--script_arg",
                 "foo",
             ],
@@ -143,7 +148,28 @@ class ElasticRoleBuilderTest(unittest.TestCase):
                 "etcd",
                 "--rdzv_id",
                 macros.app_id,
-                "user_script.py",
+                "--role",
+                "test_role",
+                os.path.join(macros.img_root, "user_script.py"),
+            ],
+            role.args,
+        )
+
+    def test_build_elastic_role_img_root_already_in_entrypoint(self):
+        role = ElasticRole("test_role", no_python=False).runs(
+            os.path.join(macros.img_root, "user_script.py")
+        )
+        self.assertEqual(
+            [
+                "-m",
+                "torchelastic.distributed.launch",
+                "--rdzv_backend",
+                "etcd",
+                "--rdzv_id",
+                macros.app_id,
+                "--role",
+                "test_role",
+                os.path.join(macros.img_root, "user_script.py"),
             ],
             role.args,
         )


### PR DESCRIPTION
Summary:
Three changes:

1. Add replica_id macro
2. Prefix elastic role's entrypoint with img_root macro IF it is not an absolute path
3. Add `--role = role.name` argument to pet agent in `ElasticRole`

Differential Revision: D23771296

