### PR TITLE
add ui url to the return value of session.status(app_id)

### DIFF
--- a/torchelastic/tsm/driver/api.py
+++ b/torchelastic/tsm/driver/api.py
@@ -370,6 +370,7 @@ class AppStatus:
         self.state: AppState = state
         self.num_restarts: int = num_restarts
         self.msg: str = msg
+        self.ui_url: Optional[str] = None
 
     def is_terminal(self) -> bool:
         return is_terminal(self.state)
@@ -395,6 +396,8 @@ class DescribeAppResponse:
         self.state: AppState = AppState.UNSUBMITTED
         self.num_restarts: int = -1
         self.msg: str = ""
+        self.ui_url: Optional[str] = None
+
         # TODO T72035216 add other fields that come back from the scheduler's describe
         # API. Typically this includes some type of JobDefinition which
         # contains all the data to recreate the Application object. Store them

--- a/torchelastic/tsm/driver/standalone_session.py
+++ b/torchelastic/tsm/driver/standalone_session.py
@@ -51,7 +51,9 @@ class StandaloneSession(Session):
             del self._apps[app_id]
             return None
 
-        return AppStatus(desc.state, desc.num_restarts, desc.msg)
+        app_status = AppStatus(desc.state, desc.num_restarts, desc.msg)
+        app_status.ui_url = desc.ui_url
+        return app_status
 
     def wait(self, app_id: str) -> Optional[AppStatus]:
         while True:


### PR DESCRIPTION
Summary:
Adds UI URL to `AppState`. Usage:

```
app_id = session.run(app)
app_state = session.status(app_id)
print(f"Follow link for more details: {app_state.ui_url}")
```

Differential Revision: D23861436

