### PR TITLE
Add tsm docs to the docs page, added --dry-run flag to doc_push.sh, fix a few docstring typos

### DIFF
--- a/docs/doc_push.sh
+++ b/docs/doc_push.sh
@@ -30,6 +30,15 @@
 #   Makefile (redirect target)
 #  (on gh-pages branch) _layouts/docs_redirect.html
 
+dry_run=0
+for arg in "$@"; do
+    shift
+    case "$arg" in
+        "--dry-run") dry_run=1 ;;
+        "--help") echo "Usage $0 [--dry-run]"; exit 0 ;;
+    esac
+done
+
 repo_root=$(git rev-parse --show-toplevel)
 branch=$(git rev-parse --abbrev-ref HEAD)
 commit_id=$(git rev-parse --short HEAD)
@@ -56,6 +65,12 @@ build_dir=$docs_dir/build
 cd "$docs_dir" || exit
 pip install -r requirements.txt
 make clean html
+echo "Doc build complete"
+
+if [ $dry_run -eq 1 ]; then
+    echo "*** dry-run mode, building only. See build artifacts in: $build_dir"
+    exit
+fi
 
 tmp_dir=/tmp/torchelastic_docs_tmp
 rm -rf "${tmp_dir:?}"
@@ -82,4 +97,3 @@ fi
 cd $gh_pages_dir || exit
 git add .
 git commit --quiet -m "[doc_push][$release_tag] built from $commit_id ($branch). Redirects: ${redirects[*]} -> $torchelastic_ver."
-git push

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 sphinx
-m2r
 -e git+http://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,6 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinxcontrib.katex",
     "sphinx.ext.autosectionlabel",
-    "m2r",
 ]
 
 # katex options

--- a/docs/source/events.rst
+++ b/docs/source/events.rst
@@ -5,7 +5,7 @@ Events
 
 .. automodule:: torchelastic.events
 
-Classes
+Event Handlers
 -----------------
 
 .. currentmodule:: torchelastic.events.api
@@ -19,7 +19,7 @@ Classes
 .. autoclass:: NullEventHandler
 
 
-Methods
+API Methods
 ------------
 
 .. autofunction:: torchelastic.events.configure

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,3 +50,9 @@ Documentation
 
    kubernetes
    runtime
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Experimental
+
+   tsm_driver

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -1,7 +1,7 @@
 .. _metrics-api:
 
 Metrics
-=======
+=========
 
 .. automodule:: torchelastic.metrics
 

--- a/docs/source/tsm_driver.rst
+++ b/docs/source/tsm_driver.rst
@@ -1,0 +1,62 @@
+Training Session Manager (TSM)
+===============================================
+
+Training Session Manager (TSM) is a set of programmatic APIs that
+helps you launch your distributed (PyTorch) applications onto the
+supported schedulers. Whereas torchelastic is deployed per container
+and manages worker processes and coordinates restart behaviors, TSM
+provides a way to launch the distributed job while natively supporting
+jobs that are (locally) managed by torchelastic.
+
+.. note:: TSM is currently an experimental module
+          and is subject to change for future releases of torchelastic.
+          At the moment TSM only ships with a ``LocalScheduler`` allowing
+          the user to run the distributed application locally on a dev host.
+
+Usage Overview
+----------------------
+
+.. automodule:: torchelastic.tsm.driver
+
+User API Documentation
+--------------------------
+
+.. currentmodule:: torchelastic.tsm.driver.api
+
+Containers and Resources
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: Container
+.. autoclass:: Resources
+
+Roles and Applications
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: Role
+.. autoclass:: ElasticRole
+.. autoclass:: macros
+.. autoclass:: Application
+
+Session
+~~~~~~~~~~~~~~~
+.. autoclass:: Session
+   :members:
+
+Developer API Documentation
+-----------------------------------
+.. currentmodule:: torchelastic.tsm.driver.api
+
+Scheduler
+~~~~~~~~~~~~~~~
+.. autoclass:: torchelastic.tsm.driver.api.Scheduler
+   :members:
+
+.. autoclass:: torchelastic.tsm.driver.local_scheduler.LocalScheduler
+   :members:
+
+Session Builder
+~~~~~~~~~~~~~~~~
+
+
+
+
+
+

--- a/torchelastic/distributed/launch.py
+++ b/torchelastic/distributed/launch.py
@@ -21,6 +21,7 @@ with the following additional functionalities:
 1. Single-node multi-worker (with sidecar etcd server)
 
 ::
+
     >>> python -m torchelastic.distributed.launch
         --standalone
         --nnodes=1

--- a/torchelastic/rendezvous/api.py
+++ b/torchelastic/rendezvous/api.py
@@ -123,17 +123,16 @@ class RendezvousHandler(abc.ABC):
         """
         Closes all resources that were open for rendezvous run.
 
-        Usage
+        Usage:
 
-            ::
+        ::
 
-            def main():
-                rdzv_handler = ..
-                try:
-                    rank, world_size, store = rdzv_handler.next_rendezvous()
-                finally:
-                    rdzv_handler.shutdown()
-
+         def main():
+             rdzv_handler = ...
+             try:
+               rank, world_size, store = rdzv_handler.next_rendezvous()
+             finally:
+               rdzv_handler.shutdown()
         """
         pass
 

--- a/torchelastic/tsm/driver/__init__.py
+++ b/torchelastic/tsm/driver/__init__.py
@@ -6,10 +6,66 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+r"""
+Below is a simple program that locally launches a multi-role
+(trainer, parameter server, reader) distributed application.
+Each ``Role`` runs multiple replicas. In reality each replica
+runs on its own container on a host. An ``Application`` is made up
+to one or more such ``Roles``.
+
+.. code:: python
+
+ import getpass
+ import torchelastic.tsm.driver as tsm
+
+ username = getpass.getuser()
+ train_project_dir = tsm.Container(image=f"/home/{username}/pytorch_trainer")
+ reader_project_dir = tsm.Container(image=f"/home/{username}/pytorch_reader")
+
+ trainer = tsm.Role(name="trainer")
+              .runs("train_main.py", "--epochs", "50", MY_ENV_VAR="foobar")
+              .on(train_project_dir)
+              .replicas(4)
+
+ ps = tsm.Role(name="parameter_server")
+         .run("ps_main.py")
+         .on(train_project_dir)
+         .replicas(10)
+
+ reader = tsm.Role(name="reader")
+             .runs("reader/reader_main.py", "--buffer_size", "1024")
+             .on(reader_project_dir)
+             .replicas(1)
+
+ app = tsm.Application(name="my_train_job").of(trainer, ps, reader)
+
+ session = tsm.session(name="my_session", scheduler_backend="local")
+ app_id = session.run(app)
+ session.wait(app_id)
+
+In the example above, we have done a few things:
+
+1. Created and ran a distributed training application that runs a total of
+   4 + 10 + 1 = 15 containers (just processes since we used a ``local`` scheduler).
+2. The ``trainer`` and ``ps`` run from the same container:
+   ``/home/$USER/pytorch_trainer`` and the reader runs from a container:
+   ``/home/$USER/pytorch_reader``. The containers map to a local directory
+   because we are using a local scheduler. For other non-trivial schedulers
+   a container could map to a Docker image, tarball, rpm, etc.
+3. The main entrypoints are relative to the container image's root dir.
+   For example, the trainer runs ``/home/$USER/pytorch_trainer/train_main.py``.
+4. Arguments to each role entrypoint are passed as ``*args`` after the entrypoint CMD.
+5. Environment variables to each role entrypoint are passed as ``**kwargs``
+   after the arguments.
+6. The ``session`` object has action APIs on the app: ``run``, ``describe``, and ``wait``.
+
+
+"""
 from torchelastic.tsm.driver.api import (  # noqa: F401 F403
     Application,
     AppState,
     Container,
+    ElasticRole,
     Resources,
     Role,
     RunMode,
@@ -27,9 +83,9 @@ except ModuleNotFoundError:
 
 
 def session(
-    name: str, scheduler_type: str, backend: str = "standalone", **scheduler_args
+    name: str, scheduler_backend: str, backend: str = "standalone", **scheduler_args
 ):
-    scheduler = get_scheduler(scheduler_type, **scheduler_args)
+    scheduler = get_scheduler(scheduler_backend, **scheduler_args)
     if backend != "standalone":
         raise ValueError(
             f"Unsupported session backend: {backend}. Supported values: standalone"

--- a/torchelastic/tsm/driver/api.py
+++ b/torchelastic/tsm/driver/api.py
@@ -71,7 +71,7 @@ class Container:
 
     ::
 
-    my_container = Container(image="pytorch/torch:1")
+     my_container = Container(image="pytorch/torch:1")
                        .require(Resources(cpu=1, gpu=1, memMB=500))
                        .ports(tcp_store=8080, tensorboard=8081)
     """
@@ -123,11 +123,12 @@ class macros:
 
     ::
 
-    trainer = Role(name="trainer").runs("hello_world.py", "--app_id", macros.app_id)
-    app = Application("train_app").of(trainer)
-    app_id = session.run(app)
+     # runs: hello_world.py --app_id ${app_id}
+     trainer = Role(name="trainer").runs("hello_world.py", "--app_id", macros.app_id)
+     app = Application("train_app").of(trainer)
+     app_id = session.run(app)
 
-    # runs: hello_world.py --app_id ${app_id}
+
     """
 
     img_root = "${img_root}"
@@ -159,7 +160,7 @@ class Role:
 
     ::
 
-    trainer = Role(name="trainer")
+     trainer = Role(name="trainer")
                  .runs("my_trainer.py", "--arg", "foo", ENV_VAR="FOOBAR")
                  .on(container)
                  .replicas(4)
@@ -225,19 +226,20 @@ class ElasticRole(Role):
     .. warning:: ``replicas`` MUST BE an integer between (inclusive) ``nnodes``. That is,
                    ``ElasticRole("trainer", nnodes="2:4").replicas(5)`` is invalid and will
                    result in undefined behavior.
+
     ::
 
-    # effectively runs:
-    #    python -m torchelastic.distributed.launch
-    #        --nproc_per_node 8
-    #        --nnodes 2:4
-    #        --max_restarts 3
-    #        my_train_script.py --script_arg foo --another_arg bar
+     # effectively runs:
+     #    python -m torchelastic.distributed.launch
+     #        --nproc_per_node 8
+     #        --nnodes 2:4
+     #        --max_restarts 3
+     #        my_train_script.py --script_arg foo --another_arg bar
 
-    elastic_trainer = ElasticRole("trainer", nproc_per_node=8, nnodes="2:4", max_restarts=3)
-                      .runs("my_train_script.py", "--script_arg", "foo", "--another_arg", "bar")
-                      .on(container)
-                      .replicas(2)
+     elastic_trainer = ElasticRole("trainer", nproc_per_node=8, nnodes="2:4", max_restarts=3)
+                        .runs("my_train_script.py", "--script_arg", "foo", "--another_arg", "bar")
+                        .on(container)
+                        .replicas(2)
 
     """
 
@@ -550,11 +552,11 @@ class Session(abc.ABC):
 
         ::
 
-        while(True):
-            app_status = status(app)
-            if app_status.is_terminal():
-                return
-            sleep(10)
+         while(True):
+             app_status = status(app)
+             if app_status.is_terminal():
+                 return
+             sleep(10)
 
         Returns:
             The terminal status of the application, or ``None`` if the app does not exist anymore


### PR DESCRIPTION
Summary:
1. Adds tsm docs to https://pytorch.org/elastic
2. Adds `--dry-run` flag to `doc_push.sh`
3. Fixes a few doc string typos
4. Changes `scheduler_type` to `scheduler_backend` to be more consistent in session builder.

Differential Revision: D23977774

