### PR TITLE
make torchelastic.distributed.launch args settable from env var with name PET_ARG

### DIFF
--- a/torchelastic/distributed/argparse_util.py
+++ b/torchelastic/distributed/argparse_util.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+from argparse import Action
+
+
+class env(Action):
+    """
+    Gets argument values from ``PET_{dest}`` before defaulting
+    to the given ``default`` value. For flags (e.g. ``--standalone``)
+    use ``check_env`` instead.
+
+    .. note:: when multiple option strings are specified, ``dest`` is
+              the longest option string (e.g. for ``"-f", "--foo"``
+              the env var to set is ``PET_FOO`` not ``PET_F``)
+
+    Example:
+
+    ::
+
+     parser.add_argument("-f", "--foo", action=env, default="bar")
+
+     ./program                                      -> args.foo="bar"
+     ./program -f baz                               -> args.foo="baz"
+     ./program --foo baz                            -> args.foo="baz"
+     PET_FOO="env_bar" ./program -f baz    -> args.foo="baz"
+     PET_FOO="env_bar" ./program --foo baz -> args.foo="baz"
+     PET_FOO="env_bar" ./program           -> args.foo="env_bar"
+
+     parser.add_argument("-f", "--foo", action=env, required=True)
+
+     ./program                                      -> fails
+     ./program -f baz                               -> args.foo="baz"
+     PET_FOO="env_bar" ./program           -> args.foo="env_bar"
+     PET_FOO="env_bar" ./program -f baz    -> args.foo="baz"
+    """
+
+    def __init__(self, dest, default=None, required=False, **kwargs) -> None:
+        env_name = f"PET_{dest.upper()}"
+        default = os.environ.get(env_name, default)
+
+        # ``required`` means that it NEEDS to be present  in the command-line args
+        # rather than "this option requires a value (either set explicitly or default"
+        # so if we found default then we don't "require" it to be in the command-line
+        # so set it to False
+        if default:
+            required = False
+
+        super().__init__(dest=dest, default=default, required=required, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+
+
+class check_env(Action):
+    """
+    For flags, checks whether the env var ``PET_{dest}`` exists
+    before defaulting to the given ``default`` value. Equivalent to
+    ``store_true`` argparse built-in action except that the argument can
+    be omitted from the commandline if the env var is present and has a
+    non-zero value.
+
+    .. note:: it is redundant to pass ``default=True`` for arguments
+              that use this action because a flag should be ``True``
+              when present and ``False`` otherwise.
+
+    Example:
+
+    ::
+
+     parser.add_argument("--verbose", action=check_env)
+
+     ./program                                  -> args.verbose=False
+     ./program --verbose                        -> args.verbose=True
+     PET_VERBOSE=1 ./program           -> args.verbose=True
+     PET_VERBOSE=0 ./program           -> args.verbose=False
+     PET_VERBOSE=0 ./program --verbose -> args.verbose=True
+
+    Anti-pattern (don't do this):
+
+    ::
+
+     parser.add_argument("--verbose", action=check_env, default=True)
+
+     ./program                                  -> args.verbose=True
+     ./program --verbose                        -> args.verbose=True
+     PET_VERBOSE=1 ./program           -> args.verbose=True
+     PET_VERBOSE=0 ./program           -> args.verbose=False
+
+    """
+
+    def __init__(self, dest, default=False, **kwargs) -> None:
+        env_name = f"PET_{dest.upper()}"
+        default = bool(int(os.environ.get(env_name, "1" if default else "0")))
+        super().__init__(dest=dest, const=True, default=default, nargs=0, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, self.const)

--- a/torchelastic/distributed/launch.py
+++ b/torchelastic/distributed/launch.py
@@ -230,6 +230,7 @@ import torchelastic.rendezvous.registry as rdzv_registry
 from torchelastic import metrics
 from torchelastic.agent.server.api import WorkerGroupFailureException, WorkerSpec
 from torchelastic.agent.server.local_elastic_agent import LocalElasticAgent
+from torchelastic.distributed.argparse_util import check_env, env
 from torchelastic.rendezvous import RendezvousParameters
 from torchelastic.rendezvous.etcd_server import EtcdServer
 from torchelastic.utils.logging import get_logger
@@ -249,12 +250,14 @@ def parse_args(args):
     # worker/node size related arguments
     parser.add_argument(
         "--nnodes",
+        action=env,
         type=str,
         default="1:1",
         help="number of nodes or MIN_NODES:MAX_NODES",
     )
     parser.add_argument(
         "--nproc_per_node",
+        action=env,
         type=str,
         default="auto",
         help="number of workers per node, supported values: [auto, cpu, gpu, int]",
@@ -262,27 +265,32 @@ def parse_args(args):
 
     # rendezvous related arguments
     parser.add_argument(
-        "--rdzv_backend", type=str, default="etcd", help="rendezvous backend"
+        "--rdzv_backend",
+        action=env,
+        type=str,
+        default="etcd",
+        help="rendezvous backend",
     )
     parser.add_argument(
         "--rdzv_endpoint",
+        action=env,
         type=str,
         default="",
         help="rendezvous backend server host:port",
     )
-    parser.add_argument("--rdzv_id", type=str, help="user defined group id")
+    parser.add_argument("--rdzv_id", action=env, type=str, help="user defined group id")
     parser.add_argument(
         "--rdzv_conf",
+        action=env,
         type=str,
         default="",
         help="additional rdzv configuration (conf1=v1,conf2=v2,...)",
     )
 
-    # sidecar embed rdzv backend that defults to etcd
+    # sidecar embed rdzv backend that defaults to etcd
     parser.add_argument(
         "--standalone",
-        default=False,
-        action="store_true",
+        action=check_env,
         help="starts a local, standalone rdzv backend that is represented by"
         " etcd server on a random free port"
         "using the etcd binary specified in TORCHELASTIC_ETCD_BINARY_PATH"
@@ -295,39 +303,44 @@ def parse_args(args):
     # user-code launch related arguments
     parser.add_argument(
         "--max_restarts",
+        action=env,
         type=int,
         default=3,
         help="max number of worker group restarts before failing",
     )
     parser.add_argument(
         "--monitor_interval",
+        action=env,
         type=float,
         default=5,
         help="interval (in seconds) to monitor the state of workers",
     )
     parser.add_argument(
         "--start_method",
+        action=env,
         type=str,
         default="spawn",
         choices=["spawn", "fork", "forkserver"],
         help="multiprocessing start_method to use when creating workers",
     )
     parser.add_argument(
-        "--role", type=str, default="default", help="user-defined role for the workers"
+        "--role",
+        action=env,
+        type=str,
+        default="default",
+        help="user-defined role for the workers",
     )
     parser.add_argument(
         "-m",
         "--module",
-        default=False,
-        action="store_true",
+        action=check_env,
         help="Changes each process to interpret the launch script "
         "as a python module, executing with the same behavior as"
         "'python -m'.",
     )
     parser.add_argument(
         "--no_python",
-        default=False,
-        action="store_true",
+        action=check_env,
         help='Do not prepend the training script with "python" - just exec '
         "it directly. Useful when the script is not a Python script.",
     )

--- a/torchelastic/distributed/test/argparse_util_test.py
+++ b/torchelastic/distributed/test/argparse_util_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+import unittest
+from argparse import ArgumentParser
+
+from torchelastic.distributed.argparse_util import check_env, env
+
+
+class ArgParseUtilTest(unittest.TestCase):
+    def setUp(self):
+        # remove any lingering environment variables
+        for e in os.environ.keys():
+            if e.startswith("PET_"):
+                del os.environ[e]
+
+    def test_env_string_arg_no_env(self):
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env, default="bar")
+
+        self.assertEqual("bar", parser.parse_args([]).foo)
+        self.assertEqual("baz", parser.parse_args(["-f", "baz"]).foo)
+        self.assertEqual("baz", parser.parse_args(["--foo", "baz"]).foo)
+
+    def test_env_string_arg_env(self):
+        os.environ["PET_FOO"] = "env_baz"
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env, default="bar")
+
+        self.assertEqual("env_baz", parser.parse_args([]).foo)
+        self.assertEqual("baz", parser.parse_args(["-f", "baz"]).foo)
+        self.assertEqual("baz", parser.parse_args(["--foo", "baz"]).foo)
+
+    def test_env_int_arg_no_env(self):
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env, default=1, type=int)
+
+        self.assertEqual(1, parser.parse_args([]).foo)
+        self.assertEqual(2, parser.parse_args(["-f", "2"]).foo)
+        self.assertEqual(2, parser.parse_args(["--foo", "2"]).foo)
+
+    def test_env_int_arg_env(self):
+        os.environ["PET_FOO"] = "3"
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env, default=1, type=int)
+
+        self.assertEqual(3, parser.parse_args([]).foo)
+        self.assertEqual(2, parser.parse_args(["-f", "2"]).foo)
+        self.assertEqual(2, parser.parse_args(["--foo", "2"]).foo)
+
+    def test_env_no_default_no_env(self):
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env)
+
+        self.assertIsNone(parser.parse_args([]).foo)
+        self.assertEqual("baz", parser.parse_args(["-f", "baz"]).foo)
+        self.assertEqual("baz", parser.parse_args(["--foo", "baz"]).foo)
+
+    def test_env_no_default_env(self):
+        os.environ["PET_FOO"] = "env_baz"
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env)
+
+        self.assertEqual("env_baz", parser.parse_args([]).foo)
+        self.assertEqual("baz", parser.parse_args(["-f", "baz"]).foo)
+        self.assertEqual("baz", parser.parse_args(["--foo", "baz"]).foo)
+
+    def test_env_required_no_env(self):
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env, required=True)
+
+        self.assertEqual("baz", parser.parse_args(["-f", "baz"]).foo)
+        self.assertEqual("baz", parser.parse_args(["--foo", "baz"]).foo)
+
+    def test_env_required_env(self):
+        os.environ["PET_FOO"] = "env_baz"
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env, default="bar", required=True)
+
+        self.assertEqual("env_baz", parser.parse_args([]).foo)
+        self.assertEqual("baz", parser.parse_args(["-f", "baz"]).foo)
+        self.assertEqual("baz", parser.parse_args(["--foo", "baz"]).foo)
+
+    def test_check_env_no_env(self):
+        parser = ArgumentParser()
+        parser.add_argument("-v", "--verbose", action=check_env)
+
+        self.assertFalse(parser.parse_args([]).verbose)
+        self.assertTrue(parser.parse_args(["-v"]).verbose)
+        self.assertTrue(parser.parse_args(["--verbose"]).verbose)
+
+    def test_check_env_default_no_env(self):
+        parser = ArgumentParser()
+        parser.add_argument("-v", "--verbose", action=check_env, default=True)
+
+        self.assertTrue(parser.parse_args([]).verbose)
+        self.assertTrue(parser.parse_args(["-v"]).verbose)
+        self.assertTrue(parser.parse_args(["--verbose"]).verbose)
+
+    def test_check_env_env_zero(self):
+        os.environ["PET_VERBOSE"] = "0"
+        parser = ArgumentParser()
+        parser.add_argument("-v", "--verbose", action=check_env)
+
+        self.assertFalse(parser.parse_args([]).verbose)
+        self.assertTrue(parser.parse_args(["--verbose"]).verbose)
+
+    def test_check_env_env_one(self):
+        os.environ["PET_VERBOSE"] = "1"
+        parser = ArgumentParser()
+        parser.add_argument("-v", "--verbose", action=check_env)
+
+        self.assertTrue(parser.parse_args([]).verbose)
+        self.assertTrue(parser.parse_args(["--verbose"]).verbose)
+
+    def test_check_env_default_env_zero(self):
+        os.environ["PET_VERBOSE"] = "0"
+        parser = ArgumentParser()
+        parser.add_argument("-v", "--verbose", action=check_env, default=True)
+
+        self.assertFalse(parser.parse_args([]).verbose)
+        self.assertTrue(parser.parse_args(["--verbose"]).verbose)
+
+    def test_check_env_default_env_one(self):
+        os.environ["PET_VERBOSE"] = "1"
+        parser = ArgumentParser()
+        parser.add_argument("-v", "--verbose", action=check_env, default=True)
+
+        self.assertTrue(parser.parse_args([]).verbose)
+        self.assertTrue(parser.parse_args(["--verbose"]).verbose)


### PR DESCRIPTION
Summary:
See: https://github.com/pytorch/elastic/issues/128

Allows users to specify program args via env var as such:

```
PET_NNODES="1:2" python -m torchelastic.distributed.launch \
   --rdzv_id 123 \
   my_script.py script_args
```

Differential Revision: D24098270

