### PR TITLE
unbind scheduler from session and make session apis take a scheduler backend

### DIFF
--- a/torchelastic/tsm/driver/local_scheduler.py
+++ b/torchelastic/tsm/driver/local_scheduler.py
@@ -20,11 +20,13 @@ from torchelastic.tsm.driver.api import (
     Application,
     AppState,
     DescribeAppResponse,
+    InvalidRunConfigException,
     Role,
-    RunMode,
+    RunConfig,
     Scheduler,
     is_terminal,
     macros,
+    runopts,
 )
 from torchelastic.utils.logging import get_logger
 
@@ -103,7 +105,6 @@ class _LocalApplication:
         self.state: AppState = AppState.PENDING
         # time (in seconds since epoch) when the last set_state method() was called
         self.last_updated: float = -1
-        self.run_mode: RunMode = RunMode.MANAGED
 
     def add_process(self, role_name: str, proc: subprocess.Popen) -> None:
         procs = self.role_procs.setdefault(role_name, [])
@@ -113,9 +114,6 @@ class _LocalApplication:
         self.last_updated = time.time()
         self.state = state
 
-    def set_run_mode(self, mode: RunMode):
-        self.run_mode = mode
-
     def __repr__(self):
         role_to_pid = {}
         for (role_name, procs) in self.role_procs.items():
@@ -123,7 +121,7 @@ class _LocalApplication:
             for p in procs:
                 pids.append(p.pid)
 
-        return f"{{name:{self.name}, state:{self.state}, mode:{self.run_mode}, pid_map:{role_to_pid}}}"
+        return f"{{name:{self.name}, state:{self.state}, pid_map:{role_to_pid}}}"
 
 
 class LocalScheduler(Scheduler):
@@ -144,14 +142,34 @@ class LocalScheduler(Scheduler):
              using a different scheduler.
     """
 
-    def __init__(self, image_fetcher: ImageFetcher, cache_size: int = 100):
+    def __init__(self, cache_size: int = 100):
         # TODO T72035686 replace dict with a proper LRUCache data structure
         self._apps: Dict[AppId, _LocalApplication] = {}
-        self._image_fetcher = image_fetcher
 
         if cache_size <= 0:
             raise ValueError("cache size must be greater than zero")
         self._cache_size = cache_size
+
+    def run_opts(self) -> runopts:
+        opts = runopts()
+        opts.add("image_fetcher", type_=str, help="image fetcher type", default="dir")
+        return opts
+
+    def _img_fetchers(self) -> Dict[str, ImageFetcher]:
+        return {"dir": LocalDirectoryImageFetcher()}
+
+    def _get_img_fetcher(self, cfg: RunConfig) -> ImageFetcher:
+        img_fetcher_type = cfg.get("image_fetcher")
+        fetchers = self._img_fetchers()
+        # pyre-ignore [6]: type check already done by runopt.resolve
+        img_fetcher = fetchers.get(img_fetcher_type, None)
+        if not img_fetcher:
+            raise InvalidRunConfigException(
+                f"Unsupported image fetcher type: {img_fetcher_type}. Must be one of: {fetchers.keys()}",
+                cfg,
+                self.run_opts(),
+            )
+        return img_fetcher
 
     def _evict_lru(self) -> bool:
         """
@@ -171,13 +189,6 @@ class LocalScheduler(Scheduler):
 
         if lru_app_id:
             # evict LRU finished app from the apps cache
-            # do not remove the app name from the ids map so that the ids
-            # remain unique throughout the lifespan of this scheduler
-            # for example if cache size == 1
-            #     app_id1 = submit(app)
-            #     app_id2 = submit(app) # app_id1 was evicted here
-            #     app_id1 == "app.name_0"
-            #     app_id2 == "app.name_1"
             del self._apps[lru_app_id]
 
             log.debug(f"evicting app: {lru_app_id}, from local scheduler cache")
@@ -186,7 +197,7 @@ class LocalScheduler(Scheduler):
             log.debug(f"no apps evicted, all {len(self._apps)} apps are running")
             return False
 
-    def submit(self, app: Application, mode: RunMode) -> str:
+    def _submit(self, app: Application, cfg: RunConfig) -> str:
         if len(self._apps) == self._cache_size:
             if not self._evict_lru():
                 raise IndexError(
@@ -199,9 +210,8 @@ class LocalScheduler(Scheduler):
         ), "no app_id collisons expected since uuid4 suffix is used"
 
         local_app = _LocalApplication(app.name)
-        local_app.set_run_mode(mode)
 
-        for role_popen_args in self._to_app_popen_args(app_id, app.roles):
+        for role_popen_args in self._to_app_popen_args(app_id, app.roles, cfg):
             for i, (role_name, replica_popen_args) in enumerate(
                 role_popen_args.items()
             ):
@@ -213,19 +223,15 @@ class LocalScheduler(Scheduler):
         self._apps[app_id] = local_app
         return app_id
 
-    @staticmethod
-    def _make_unique_id(app_name: str) -> str:
-        return f"{app_name}_{str(uuid4()).split('-')[0]}"
-
-    def submit_dryrun(self, app: Application, mode: RunMode) -> AppDryRunInfo:
-        app_popen_args = self._to_app_popen_args(f"{app.name}_##", app.roles)
+    def _submit_dryrun(self, app: Application, cfg: RunConfig) -> AppDryRunInfo:
+        app_popen_args = self._to_app_popen_args(f"{app.name}_##", app.roles, cfg)
         import pprint
 
         return AppDryRunInfo(
             app_popen_args, lambda p: pprint.pformat(p, indent=2, width=80)
         )
 
-    def _to_app_popen_args(self, app_id: str, roles: List[Role]):
+    def _to_app_popen_args(self, app_id: str, roles: List[Role], cfg: RunConfig):
         """
         returns the popen args for all processes that needs to be created for the app
 
@@ -260,7 +266,8 @@ class LocalScheduler(Scheduler):
                 container
             ), "all roles in a submitted app must have container association"
 
-            img_root = self._image_fetcher.fetch(container.image)
+            image_fetcher = self._get_img_fetcher(cfg)
+            img_root = image_fetcher.fetch(container.image)
             cmd = os.path.join(img_root, role.entrypoint)
 
             role_popen_params = {}
@@ -353,14 +360,11 @@ class LocalScheduler(Scheduler):
         raise TimeoutError(f"timed out waiting for app: {app_id} to finish")
 
     def __del__(self):
-        # terminate all MANAGED apps
+        # terminate all apps
         for (app_id, app) in self._apps.items():
-            if app.run_mode == RunMode.MANAGED:
-                log.info(f"Terminating managed app: {app_id}")
-                self._cancel_existing(app_id)
+            log.info(f"Terminating app: {app_id}")
+            self._cancel_existing(app_id)
 
 
 def create_scheduler(**kwargs) -> LocalScheduler:
-    image_fetcher = LocalDirectoryImageFetcher()
-    cache_size = kwargs.get("cache_size", 100)
-    return LocalScheduler(image_fetcher, cache_size=cache_size)
+    return LocalScheduler(cache_size=kwargs.get("cache_size", 100))

--- a/torchelastic/tsm/driver/schedulers.py
+++ b/torchelastic/tsm/driver/schedulers.py
@@ -5,15 +5,14 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+from typing import Dict
 
-
-import torchelastic.tsm.driver.api as Scheduler
 import torchelastic.tsm.driver.local_scheduler as local_scheduler
+from torchelastic.tsm.driver.api import Scheduler, SchedulerBackend
 
 
-def get_scheduler(scheduler_type: str, **scheduler_params) -> Scheduler:
-    schedulers = {"local": local_scheduler.create_scheduler}
-    if scheduler_type not in schedulers:
-        raise ValueError(f"Unknown scheduler type: {scheduler_type}")
-    scheduler_create_method = schedulers[scheduler_type]
-    return scheduler_create_method(**scheduler_params)
+def get_schedulers(**scheduler_params) -> Dict[SchedulerBackend, Scheduler]:
+    return {
+        "local": local_scheduler.create_scheduler(**scheduler_params),
+        "default": local_scheduler.create_scheduler(**scheduler_params),
+    }

--- a/torchelastic/tsm/driver/standalone_session.py
+++ b/torchelastic/tsm/driver/standalone_session.py
@@ -9,69 +9,128 @@ import time
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 from datetime import datetime
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from torchelastic.tsm.driver.api import (
     AppDryRunInfo,
+    AppHandle,
     Application,
-    AppNotReRunnableException,
     AppStatus,
-    RunMode,
+    RunConfig,
     Scheduler,
+    SchedulerBackend,
     Session,
+    SessionMismatchException,
     UnknownAppException,
+    make_app_handle,
+    parse_app_handle,
     runopts,
 )
 
 
 class StandaloneSession(Session):
-    def __init__(self, name: str, scheduler: Scheduler, wait_interval: int = 10):
+    def __init__(
+        self,
+        name: str,
+        schedulers: Dict[SchedulerBackend, Scheduler],
+        wait_interval: int = 10,
+    ):
+        if "default" not in schedulers:
+            raise ValueError(
+                f"A default scheduler is required. Provided schedulers: {schedulers.keys()}"
+            )
+
         super().__init__(name)
-        self._scheduler = scheduler
+        self._schedulers = schedulers
         self._wait_interval = wait_interval
 
         # TODO T72035686 implement an LRU cache (see local_scheduler.py) and use it here and also in local_scheduler
-        # app_id -> Application
-        self._apps: Dict[str, Application] = {}
+        self._apps: Dict[AppHandle, Application] = {}
 
-    def run(self, app: Application, mode: RunMode = RunMode.HEADLESS) -> str:
-        if app.is_attached:
-            raise AppNotReRunnableException(app)
-        return super().run(app, mode)
+    def _scheduler(self, scheduler: SchedulerBackend) -> Scheduler:
+        sched = self._schedulers.get(scheduler)
+        if not sched:
+            raise KeyError(
+                f"Undefined scheduler backend: {scheduler}. Use one of: {self._schedulers.keys()}"
+            )
+        return sched
 
-    def _run(self, app: Application, mode: RunMode = RunMode.HEADLESS) -> str:
-        app_id = self._scheduler.submit(app, mode)
-        self._apps[app_id] = app
-        return app_id
+    def _scheduler_app_id(
+        self, app_handle: AppHandle, check_session: bool = True
+    ) -> Tuple[Scheduler, str]:
+        """
+        Returns the scheduler and app_id from the app_handle.
+        Set ``check_session`` to validate that the session name in the app handle
+        is the same as this session.
 
-    def dryrun(
-        self, app: Application, mode: RunMode = RunMode.HEADLESS
+        Raises:
+            ValueError - if ``check_session=True`` and the session in the app handle
+                         does not match this session's name
+            KeyError - if no such scheduler backend exists
+        """
+
+        scheduler_backend, session_name, app_id = parse_app_handle(app_handle)
+        if check_session and self._name != session_name:
+            raise SessionMismatchException(app_handle, self._name)
+        scheduler = self._scheduler(scheduler_backend)
+        return scheduler, app_id
+
+    def run(
+        self,
+        app: Application,
+        scheduler: SchedulerBackend = "default",
+        cfg: Optional[RunConfig] = None,
+    ) -> AppHandle:
+        return super().run(app, scheduler, cfg)
+
+    def _run(
+        self,
+        app: Application,
+        scheduler: SchedulerBackend,
+        cfg: RunConfig,
+    ) -> str:
+        sched = self._scheduler(scheduler)
+        app_id = sched.submit(app, cfg)
+        app_handle = make_app_handle(scheduler, self._name, app_id)
+        self._apps[app_handle] = app
+        return app_handle
+
+    def _dryrun(
+        self,
+        app: Application,
+        scheduler: SchedulerBackend,
+        cfg: RunConfig,
     ) -> AppDryRunInfo:
-        return self._scheduler.submit_dryrun(app, mode)
+        sched = self._scheduler(scheduler)
+        return sched.submit_dryrun(app, cfg)
 
     def run_opts(self) -> Dict[str, runopts]:
-        # TODO key will be the scheduler backend (to be done in the next diff)
-        # proxying it with class name for now
-        return {self._scheduler.__class__.__qualname__: self._scheduler.run_opts()}
+        return {
+            scheduler_backend: scheduler.run_opts()
+            for scheduler_backend, scheduler in self._schedulers.items()
+        }
 
-    def status(self, app_id: str) -> Optional[AppStatus]:
-        if app_id not in self._apps:
-            raise UnknownAppException(app_id)
+    def scheduler_backends(self) -> List[SchedulerBackend]:
+        return list(self._schedulers.keys())
 
-        desc = self._scheduler.describe(app_id)
+    def status(self, app_handle: AppHandle) -> Optional[AppStatus]:
+        # allow status checks of apps from other sessions
+        scheduler, app_id = self._scheduler_app_id(app_handle, check_session=False)
+        desc = scheduler.describe(app_id)
         if not desc:
-            # app does not exist on the scheduler; remove it from apps cache
+            # app does not exist on the scheduler
+            # remove it from apps cache if it exists
             # effectively removes this app from the list() API
-            del self._apps[app_id]
+            self._apps.pop(app_handle, None)
             return None
 
         app_status = AppStatus(desc.state, desc.num_restarts, desc.msg)
         app_status.ui_url = desc.ui_url
         return app_status
 
-    def wait(self, app_id: str) -> Optional[AppStatus]:
+    def wait(self, app_handle: AppHandle) -> Optional[AppStatus]:
         while True:
-            app_status = self.status(app_id)
+            app_status = self.status(app_handle)
 
             if not app_status:
                 return None
@@ -80,7 +139,7 @@ class StandaloneSession(Session):
             else:
                 time.sleep(self._wait_interval)
 
-    def list(self) -> Dict[str, Application]:
+    def list(self) -> Dict[AppHandle, Application]:
         # opportunistically query for each app's status to update the app
         # copy the keys (app ids) since status(app_id) mutates self._apps
         app_ids = list(self._apps.keys())
@@ -88,34 +147,39 @@ class StandaloneSession(Session):
             self.status(app_id)
         return self._apps
 
-    def stop(self, app_id: str) -> None:
-        status = self.status(app_id)
+    def stop(self, app_handle: AppHandle) -> None:
+        scheduler, app_id = self._scheduler_app_id(app_handle)
+        status = self.status(app_handle)
         if status is None or status.is_terminal():
             return  # do nothing; app does not exist or has already finished
         else:
-            self._scheduler.cancel(app_id)
+            scheduler.cancel(app_id)
 
-    def attach(self, app_id: str) -> Application:
-        desc = self._scheduler.describe(app_id)
+    def describe(self, app_handle: AppHandle) -> Optional[Application]:
+        scheduler, app_id = self._scheduler_app_id(app_handle, check_session=False)
 
+        # if the app is in the apps list, then short circuit everything and return it
+        app = self._apps.get(app_handle, None)
+        if app:
+            return app
+
+        desc = scheduler.describe(app_id)
         if not desc:
-            raise UnknownAppException(app_id)
-
-        app = Application(name=app_id).of(*desc.roles)
-        app.is_attached = True
-        self._apps[app_id] = app
-        return app
+            return None
+        else:
+            return Application(name=app_id).of(*desc.roles)
 
     def log_lines(
         self,
-        app_id: str,
+        app_handle: AppHandle,
         role_name: str,
         k: int = 0,
         regex: Optional[str] = None,
         since: Optional[datetime] = None,
         until: Optional[datetime] = None,
     ) -> Iterable:
-        if not self._scheduler.exists(app_id):
-            raise UnknownAppException(app_id)
+        if not self.status(app_handle):
+            raise UnknownAppException(app_handle)
 
-        return self._scheduler.log_iter(app_id, role_name, k, regex, since, until)
+        scheduler, app_id = self._scheduler_app_id(app_handle)
+        return scheduler.log_iter(app_id, role_name, k, regex, since, until)

--- a/torchelastic/tsm/driver/test/local_scheduler_test.py
+++ b/torchelastic/tsm/driver/test/local_scheduler_test.py
@@ -17,7 +17,7 @@ from torchelastic.tsm.driver.api import (
     AppState,
     Container,
     Role,
-    RunMode,
+    RunConfig,
     macros,
 )
 from torchelastic.tsm.driver.local_scheduler import (
@@ -64,9 +64,7 @@ class LocalSchedulerTest(unittest.TestCase):
         write_shell_script(self.test_dir, "fail.sh", ["exit 1"])
         write_shell_script(self.test_dir, "sleep.sh", ["sleep $1"])
 
-        self.image_fetcher = LocalDirectoryImageFetcher()
-        self.scheduler = LocalScheduler(self.image_fetcher)
-
+        self.scheduler = LocalScheduler()
         self.test_container = Container(image=self.test_dir)
 
     def tearDown(self):
@@ -86,7 +84,8 @@ class LocalSchedulerTest(unittest.TestCase):
         app = Application(name="test_app").of(role)
         expected_app_id = LocalScheduler._make_unique_id(app.name)
         with patch(LOCAL_SCHEDULER_MAKE_UNIQUE_ID, return_value=expected_app_id):
-            app_id = self.scheduler.submit(app, RunMode.HEADLESS)
+            cfg = RunConfig()
+            app_id = self.scheduler.submit(app, cfg)
 
         self.assertEqual(f"{expected_app_id}", app_id)
         self.assertEqual(AppState.SUCCEEDED, self.scheduler.wait(app_id).state)
@@ -100,7 +99,7 @@ class LocalSchedulerTest(unittest.TestCase):
         app = Application(name="test_app").of(role)
         expected_app_id = LocalScheduler._make_unique_id(app.name)
         with patch(LOCAL_SCHEDULER_MAKE_UNIQUE_ID, return_value=expected_app_id):
-            app_id = self.scheduler.submit(app, RunMode.HEADLESS)
+            app_id = self.scheduler.submit(app, cfg)
 
         self.assertEqual(f"{expected_app_id}", app_id)
         self.assertEqual(AppState.FAILED, self.scheduler.wait(app_id).state)
@@ -120,7 +119,8 @@ class LocalSchedulerTest(unittest.TestCase):
         )
 
         app = Application(name="test_app").of(master, trainer)
-        info = self.scheduler.submit_dryrun(app, RunMode.HEADLESS)
+        cfg = RunConfig()
+        info = self.scheduler.submit_dryrun(app, cfg)
         print(info)
         self.assertEqual(2, len(info.request))
         master_info = info.request[0]["master"]
@@ -150,7 +150,8 @@ class LocalSchedulerTest(unittest.TestCase):
             .replicas(1)
         )
         app = Application(name="test_app").of(role1, role2)
-        app_id = self.scheduler.submit(app, RunMode.HEADLESS)
+        cfg = RunConfig()
+        app_id = self.scheduler.submit(app, cfg)
 
         self.assertEqual(AppState.SUCCEEDED, self.scheduler.wait(app_id).state)
         self.assertTrue(os.path.isfile(test_file1))
@@ -159,8 +160,9 @@ class LocalSchedulerTest(unittest.TestCase):
     def test_describe(self):
         role = Role("role1").runs("sleep.sh", "2").on(self.test_container).replicas(1)
         app = Application(name="test_app").of(role)
+        cfg = RunConfig()
         self.assertIsNone(self.scheduler.describe("test_app_0"))
-        app_id = self.scheduler.submit(app, RunMode.HEADLESS)
+        app_id = self.scheduler.submit(app, cfg)
         desc = self.scheduler.describe(app_id)
         self.assertEqual(AppState.RUNNING, desc.state)
         self.assertEqual(AppState.SUCCEEDED, self.scheduler.wait(app_id).state)
@@ -168,7 +170,8 @@ class LocalSchedulerTest(unittest.TestCase):
     def test_cancel(self):
         role = Role("role1").runs("sleep.sh", "10").on(self.test_container).replicas(1)
         app = Application(name="test_app").of(role)
-        app_id = self.scheduler.submit(app, RunMode.HEADLESS)
+        cfg = RunConfig()
+        app_id = self.scheduler.submit(app, cfg)
         desc = self.scheduler.describe(app_id)
         self.assertEqual(AppState.RUNNING, desc.state)
         self.scheduler.cancel(app_id)
@@ -177,7 +180,8 @@ class LocalSchedulerTest(unittest.TestCase):
     def test_exists(self):
         role = Role("role1").runs("sleep.sh", "10").on(self.test_container).replicas(1)
         app = Application(name="test_app").of(role)
-        app_id = self.scheduler.submit(app, RunMode.HEADLESS)
+        cfg = RunConfig()
+        app_id = self.scheduler.submit(app, cfg)
 
         self.assertTrue(self.scheduler.exists(app_id))
         self.scheduler.cancel(app_id)
@@ -185,33 +189,35 @@ class LocalSchedulerTest(unittest.TestCase):
 
     def test_invalid_cache_size(self):
         with self.assertRaises(ValueError):
-            LocalScheduler(self.image_fetcher, cache_size=0)
+            LocalScheduler(cache_size=0)
 
         with self.assertRaises(ValueError):
-            LocalScheduler(self.image_fetcher, cache_size=-1)
+            LocalScheduler(cache_size=-1)
 
     def test_cache_full(self):
-        scheduler = LocalScheduler(self.image_fetcher, cache_size=1)
+        scheduler = LocalScheduler(cache_size=1)
 
         role = Role("role1").runs("sleep.sh", "10").on(self.test_container).replicas(1)
         app = Application(name="test_app").of(role)
-        scheduler.submit(app, RunMode.MANAGED)
+        cfg = RunConfig()
+        scheduler.submit(app, cfg)
         with self.assertRaises(IndexError):
-            scheduler.submit(app, RunMode.MANAGED)
+            scheduler.submit(app, cfg)
 
     def test_cache_evict(self):
-        scheduler = LocalScheduler(self.image_fetcher, cache_size=1)
+        scheduler = LocalScheduler(cache_size=1)
         test_file1 = os.path.join(self.test_dir, "test_file_1")
         test_file2 = os.path.join(self.test_dir, "test_file_2")
         role1 = Role("role1").runs("touch.sh", test_file1).on(self.test_container)
         role2 = Role("role2").runs("touch.sh", test_file2).on(self.test_container)
         app1 = Application(name="touch_test_file1").of(role1)
         app2 = Application(name="touch_test_file2").of(role2)
+        cfg = RunConfig()
 
-        app_id1 = scheduler.submit(app1, RunMode.HEADLESS)
+        app_id1 = scheduler.submit(app1, cfg)
         self.assertEqual(AppState.SUCCEEDED, scheduler.wait(app_id1).state)
 
-        app_id2 = scheduler.submit(app2, RunMode.HEADLESS)
+        app_id2 = scheduler.submit(app2, cfg)
         self.assertEqual(AppState.SUCCEEDED, scheduler.wait(app_id2).state)
 
         # app1 should've been evicted

--- a/torchelastic/tsm/driver/test/schedulers_test.py
+++ b/torchelastic/tsm/driver/test/schedulers_test.py
@@ -8,15 +8,12 @@
 
 import unittest
 
-from torchelastic.tsm.driver.schedulers import get_scheduler
+from torchelastic.tsm.driver.local_scheduler import LocalScheduler
+from torchelastic.tsm.driver.schedulers import get_schedulers
 
 
 class SchedulersTest(unittest.TestCase):
     def test_get_local_schedulers(self):
-        scheduler = get_scheduler("local", cache_size=250)
-        self.assertIsNotNone(scheduler)
-        self.assertEquals(250, scheduler._cache_size)
-
-    def test_get_unknown_scheduler(self):
-        with self.assertRaises(ValueError):
-            get_scheduler("unknown_scheduler", cache_size=250)
+        schedulers = get_schedulers()
+        self.assertTrue(isinstance(schedulers["local"], LocalScheduler))
+        self.assertTrue(isinstance(schedulers["default"], LocalScheduler))


### PR DESCRIPTION
Summary:
1. changes `session.run` to now take `Application, RunConfig, SchedulerBackend` and return an `AppHandle`
2. changes other `session` APIs (`wait`, `stop`, etc) to take `AppHandle` (instead of `app_id`)
3. Removes unused `RunMode.HEADLESS|MANAGED`
4. Removes `session.attach`
5. Move `LocalScheduler.image_fetcher` to run config (from ctor)
6. Move `mast_smc_tier` into runopts (from ctro)
7. Changes to ttk launcher, revamp ttk launcher test, up code coverage from 90 -> 97%.

Differential Revision: D24525097

