### PR TITLE
Fix circle CI breakage by depending on torch-1.8.0dev (nightly)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,13 @@ install_dep: &install_dep
         echo "In venv: $(pyenv local) - $(python --version), $(pip --version)"
         python --version
         pip --version
+        # TODO remove when torch-1.8.0 releases
+        pip uninstall -y torch
+        if [[ -z ${CUDA_VERSION} ]]; then
+          pip install --progress-bar off --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        else
+          pip install --progress-bar off --pre torch -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
+        fi
         pip install --progress-bar off -r requirements.txt
         pip install --progress-bar off black isort
         pip list

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 numpy
 python-etcd>=0.4.5
-torch==1.7.0
+# please install torch nightly by following the instructions on
+# https://pytorch.org/
+torch>=1.8.0dev


### PR DESCRIPTION
Summary:
CircleCI test breaks b/c one of our tests depend on `torch.multiprocessing.spawn.ProcessRaisedException` which was not released with torch-1.7.0. https://github.com/pytorch/elastic/blob/master/torchelastic/multiprocessing/test/mp_test.py#L14

Depend on  torch-1.8.0dev until this is included in torch-1.8.0.

Differential Revision: D24843347

