### PR TITLE
Enable NCCL_ASYNC_ERROR_HANDLING in torchelastic

### DIFF
--- a/torchelastic/agent/server/local_elastic_agent.py
+++ b/torchelastic/agent/server/local_elastic_agent.py
@@ -144,6 +144,7 @@ class LocalElasticAgent(SimpleElasticAgent):
                 "TORCHELASTIC_RESTART_COUNT": str(restart_count),
                 "TORCHELASTIC_MAX_RESTARTS": str(spec.max_restarts),
                 "TORCHELASTIC_RUN_ID": spec.rdzv_handler.get_run_id(),
+                "NCCL_ASYNC_ERROR_HANDLING": str(1),
             }
             if "OMP_NUM_THREADS" in os.environ:
                 worker_env["OMP_NUM_THREADS"] = os.environ["OMP_NUM_THREADS"]


### PR DESCRIPTION
Summary:
NCCL Async Error Handling is a new mechanism implemented in ProcessGroupNCCL to provide reliability for DDP training runs using NCCL. See here for a more detailed background and implementation details: https://github.com/pytorch/pytorch/issues/46874.

At a high-level, this system was designed to ensure desynchronization, high GPU utilization, and NCCL errors don't cause indefinite hanging in distributed training runs. This system catches these errors without any perf impact and brings down the training process, and torchelastic can detect this and restart training from the previous checkpoint. The time after which stuck collectives are detected can be tuned using the `timeout` argument to `init_process_group`.

Fixes: https://github.com/pytorch/elastic/issues/136

Differential Revision: D23610237

