### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/torchelastic/agent/server/api.py
+++ b/torchelastic/agent/server/api.py
@@ -39,7 +39,7 @@ class WorkerSpec:
     Worker spec is expected to be homogenous across all nodes (machine),
     that is each node runs the same number of workers for a particular spec.
 
-    Arguments:
+    Args:
         role: user-defined role for the workers with this spec
         local_world_size: number local workers to run
         fn: (deprecated use entrypoint instead)
@@ -108,7 +108,7 @@ class Worker:
     agent, it could be the ``pid (int)`` of the worker, for a remote
     agent it could be encoded as ``host:port (string)``.
 
-    Arguments:
+    Args:
         id (Any): uniquely identifies a worker (interpreted by the agent)
         local_rank (int): local rank of the worker
         global_rank (int): global rank of the worker
@@ -257,7 +257,7 @@ class _RoleInstanceInfo:
     def __init__(self, role: str, rank: int, local_world_size: int):
         r"""
 
-        Arguments:
+        Args:
             role (str): user-defined role for the workers with this spec
             rank (int): the rank of the agent
             local_world_size (int): number of local workers to run

--- a/torchelastic/multiprocessing/__init__.py
+++ b/torchelastic/multiprocessing/__init__.py
@@ -167,7 +167,7 @@ def start_processes(
         log_dir=log_dir
       )
 
-    Arguments:
+    Args:
         name: a human readable short name that describes what the processes are
               (used as header when tee'ing stdout/stderr outputs)
         entrypoint: either a ``Callable`` (function) or ``cmd`` (binary)

--- a/torchelastic/tsm/driver/api.py
+++ b/torchelastic/tsm/driver/api.py
@@ -36,7 +36,7 @@ class Resource:
     """
     Represents resource requirements for a ``Container``.
 
-    Arguments:
+    Args:
             cpu: number of cpu cores (note: not hyper threads)
             gpu: number of gpus
             memMB: MB of ram
@@ -275,7 +275,7 @@ class Role:
                  .on(container)
                  .replicas(4)
 
-    Arguments:
+    Args:
             name: name of the role
             entrypoint: command (within the container) to invoke the role
             args: commandline arguments to the entrypoint cmd
@@ -1259,7 +1259,7 @@ class Session(abc.ABC):
                 break
          report(experiment_name, accuracy)
 
-        Arguments:
+        Args:
             app_handle: application handle
             role_name: role within the app (e.g. trainer)
             k: k-th replica of the role to fetch the logs for

--- a/torchelastic/utils/api.py
+++ b/torchelastic/utils/api.py
@@ -14,7 +14,7 @@ def get_env_variable_or_raise(env_name: str) -> str:
     Tries to retrieve environment variable. Raises ``ValueError``
     if no environment variable found.
 
-    Arguments:
+    Args:
         env_name (str): Name of the env variable
     """
     value = os.environ.get(env_name, None)

--- a/torchelastic/utils/data/elastic_distributed_sampler.py
+++ b/torchelastic/utils/data/elastic_distributed_sampler.py
@@ -25,7 +25,7 @@ class ElasticDistributedSampler(DistributedSampler):
     .. note::
         Dataset is assumed to be of constant size.
 
-    Arguments:
+    Args:
         dataset: Dataset used for sampling.
         num_replicas (optional): Number of processes participating in
             distributed training.

--- a/torchelastic/utils/logging.py
+++ b/torchelastic/utils/logging.py
@@ -20,7 +20,7 @@ def get_logger(name: Optional[str] = None):
     env. variable or INFO as default. The function will use the
     module name of the caller if no name is provided.
 
-    Arguments:
+    Args:
         name: Name of the logger. If no name provided, the name will
               be derived from the call stack.
     """
@@ -43,7 +43,7 @@ def _derive_module_name(depth: int = 1) -> Optional[str]:
     """
     Derives the name of the caller module from the stack frames.
 
-    Arguments:
+    Args:
         depth: The position of the frame in the stack.
     """
     try:


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue when I was parsing/generating from the TensorFlow—and now PyTorch—codebases: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see pytorch/pytorch/pull/49736