### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
 layout: docs_redirect
 title: PyTorch | Redirect
-redirect_url: "/elastic/master"
+redirect_url: "/docs/stable/distributed.elastic.html"
 ---


### PR DESCRIPTION
Redirects /elastic to the 1.9 docs in /docs/stable/distributed.elastic.html. (The alternative is to turn off gh-pages in this repo and I have a redirect that will pick up the new location.) 