### PR TITLE
Various improvements to `torch.distributed.launch` and `torch.distributed.run` (#60925)

### DIFF
--- a/torchelastic/distributed/launch.py
+++ b/torchelastic/distributed/launch.py
@@ -6,6 +6,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
+
 from torch.distributed.run import parse_args, run
 
 
@@ -15,4 +17,5 @@ def main(args=None):
 
 
 if __name__ == "__main__":
+    os.environ["LOGLEVEL"] = "INFO"
     main()


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/60925

Pull Request resolved: https://github.com/pytorch/pytorch/pull/60808

* Make `torch.distributed.launch` restarts to 0
* Remove unnecessary `-use_env` warning, move `-use_env` warnings
* Move `-use_env` warnings to `torch.distributed.launch`
* Make default log level WARNING
* Add new doc section around transitioning to `torch.distributed.run`
* Make `torch.distributed.launch` not use error-propagation
* Set default events handler to `null` that does not print events to console
* Add reference from `torch.distributed.launch` to `torch.distributed.run`
* Set correct preexec function that sends SIGTERM to child processes when parent dies

Issues resolved:

https://github.com/pytorch/pytorch/issues/60716
https://github.com/pytorch/pytorch/issues/60754

Differential Revision: D29413019

