### PR TITLE
feat(dockerfile): Use Torch 1.9 instead of nightly

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,13 +1,8 @@
-ARG BASE_IMAGE=pytorch/pytorch:1.8.0-cuda11.1-cudnn8-runtime
+ARG BASE_IMAGE=pytorch/pytorch:1.9.0-cuda10.2-cudnn7-runtime
 FROM $BASE_IMAGE
 
 # install utilities and dependencies
-RUN pip install awscli --upgrade
 RUN pip install classy-vision
-
-RUN pip uninstall -y torch
-# TODO remove and make the BASE_IMAGE pytorch:1.9.0-cuda11.1-cudnn8-runtime when torch-1.9 releases
-RUN pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Torch 1.9 is released, thus there's no need to reinstall the torch-nightly.

Signed-off-by: cegao <cegao@tencent.com>