### PR TITLE
(torchelastic) update README to point elastic CRD users to TorchX

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 1. TorchElastic has been upstreamed to PyTorch 1.9 under `torch.distributed.elastic`.
 Please refer to the PyTorch documentation [here](https://pytorch.org/docs/stable/distributed.elastic.html).
 
-2. TSM has been upstreamed to [TorchX](https://pytorch.org/torchx).
+2. The TorchElastic Controller for Kubernetes is no longer being actively maintained in favor of [TorchX](https://pytorch.org/torchx).

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,5 +1,13 @@
 ## TorchElastic Controller for Kubernetes
 
+> **IMPORTANT**
+> This CRD is no longer being actively maintained. We encourage you to look at
+> [TorchX](https://pytorch.org/torchx/latest/) to launch PyTorch jobs on Kubernetes.
+> The two relevant sections are:
+>
+> 1. TorchX-Kubernetes setup: https://pytorch.org/torchx/latest/schedulers/kubernetes.html
+> 2. TorchX dist.ddp builtin (uses torchelastic under the hood): https://pytorch.org/torchx/latest/components/distributed.html
+
 ## Overview
 
 TorchElastic Controller for Kubernetes manages a Kubernetes custom resource `ElasticJob` and makes it easy to


### PR DESCRIPTION
Summary:
The TorchElastic Kubernetes CRD is no longer actively being developed in favor of TorchX. This PR updates the README with pointers to TorchX to reflect this.

Came up in a discussion in: https://discuss.pytorch.org/t/elastic-agents-cannot-properly-shutdown-restart-after-failure/149772/4

Differential Revision: D36103550

